### PR TITLE
Add RustFox to Local and Self-Hosted AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ Tools for running LLMs locally and self-hosting AI agent platforms with full pri
 - [LM Studio](https://lmstudio.ai) - Desktop application for running local LLMs with a polished UI across all major platforms (🏷️ `TypeScript` `Electron` `Desktop`).
 - [LocalAI](https://github.com/mudler/LocalAI) - Drop-in OpenAI API replacement that runs models locally without requiring a GPU (🏷️ `Go` `Docker` `Local`).
 - [Ollama](https://github.com/ollama/ollama) - Run LLMs locally with a dead-simple CLI interface and 162K+ GitHub stars (🏷️ `Go` `CLI` `Local`).
-- [RustFox](https://github.com/chinkan/RustFox) - Self-hosted Telegram AI assistant written in Rust with sandboxed tool execution, MCP integration, persistent memory, scheduling, and agentic multi-agent orchestration via OpenRouter LLM (🏷️ `Rust` `Telegram` `Self-Hosted` `MCP` `Sandbox`).
+- [RustFox](https://github.com/chinkan/RustFox) - Self-hosted Telegram AI assistant written in Rust with sandboxed tool execution, MCP integration, persistent memory, scheduling, and multi-agent orchestration via OpenRouter (🏷️ `Rust` `Telegram` `Self-Hosted` `MCP` `Sandbox`).
 - [vLLM](https://github.com/vllm-project/vllm) - High-throughput LLM serving engine with PagedAttention for production-grade local inference (🏷️ `Python` `CUDA` `Local`).
 - [Yao Agents](https://github.com/YaoApp/yao) - Local-first AI execution platform with Docker sandbox isolation, BYOK model configuration, MCP support, 5-stage Pipeline, and multi-platform messaging via WeChat, Feishu, DingTalk, Telegram, and Discord (🏷️ `Go` `TypeScript` `Docker` `Desktop` `Self-Hosted`).
 

--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ Tools for running LLMs locally and self-hosting AI agent platforms with full pri
 - [LM Studio](https://lmstudio.ai) - Desktop application for running local LLMs with a polished UI across all major platforms (🏷️ `TypeScript` `Electron` `Desktop`).
 - [LocalAI](https://github.com/mudler/LocalAI) - Drop-in OpenAI API replacement that runs models locally without requiring a GPU (🏷️ `Go` `Docker` `Local`).
 - [Ollama](https://github.com/ollama/ollama) - Run LLMs locally with a dead-simple CLI interface and 162K+ GitHub stars (🏷️ `Go` `CLI` `Local`).
+- [RustFox](https://github.com/chinkan/RustFox) - Self-hosted Telegram AI assistant written in Rust with sandboxed tool execution, MCP integration, persistent memory, scheduling, and agentic multi-agent orchestration via OpenRouter LLM (🏷️ `Rust` `Telegram` `Self-Hosted` `MCP` `Sandbox`).
 - [vLLM](https://github.com/vllm-project/vllm) - High-throughput LLM serving engine with PagedAttention for production-grade local inference (🏷️ `Python` `CUDA` `Local`).
 - [Yao Agents](https://github.com/YaoApp/yao) - Local-first AI execution platform with Docker sandbox isolation, BYOK model configuration, MCP support, 5-stage Pipeline, and multi-platform messaging via WeChat, Feishu, DingTalk, Telegram, and Discord (🏷️ `Go` `TypeScript` `Docker` `Desktop` `Self-Hosted`).
 

--- a/README.md
+++ b/README.md
@@ -454,14 +454,14 @@ Tools for generating images, video, music, audio, and 3D assets using AI models.
 
 ### Image Generation
 
-| Generator         | Strength           | Open Source | Pricing       |
-| ----------------- | ------------------ | ----------- | ------------- |
-| Midjourney v7     | Artistic quality   | No          | $10-120/mo    |
-| FLUX 2            | Photorealism       | Yes         | Free / API    |
-| Stable Diffusion  | Full control       | Yes         | Free (OSS)    |
-| Ideogram v3       | Text rendering     | No          | Free / $7+/mo |
-| Google Imagen 4   | Highest fidelity   | No          | API           |
-| Seedream AI Studio | Multi-model (5.0/4.5/4.0) | No | Free / Paid |
+| Generator          | Strength                   | Open Source | Pricing       |
+| ------------------ | -------------------------- | ----------- | ------------- |
+| Midjourney v7      | Artistic quality           | No          | $10-120/mo    |
+| FLUX 2             | Photorealism               | Yes         | Free / API    |
+| Stable Diffusion   | Full control               | Yes         | Free (OSS)    |
+| Ideogram v3        | Text rendering             | No          | Free / $7+/mo |
+| Google Imagen 4    | Highest fidelity           | No          | API           |
+| Seedream AI Studio | Multi-model (5.0/4.5/4.0)  | No          | Free / Paid   |
 
 - [Adobe Firefly 3](https://firefly.adobe.com) - Generates commercially safe images from text prompts using a model trained exclusively on licensed data (🏷️ `Cloud` `Adobe CC` `Web`).
 - [DALL-E 3.5](https://openai.com/dall-e-3) - Generates detailed images from text prompts with 95% text accuracy integrated directly into ChatGPT (🏷️ `Cloud` `OpenAI` `API`).

--- a/README.md
+++ b/README.md
@@ -464,14 +464,14 @@ Tools for generating images, video, music, audio, and 3D assets using AI models.
 
 ### Image Generation
 
-| Generator          | Strength                   | Open Source | Pricing       |
-| ------------------ | -------------------------- | ----------- | ------------- |
-| Midjourney v7      | Artistic quality           | No          | $10-120/mo    |
-| FLUX 2             | Photorealism               | Yes         | Free / API    |
-| Stable Diffusion   | Full control               | Yes         | Free (OSS)    |
-| Ideogram v3        | Text rendering             | No          | Free / $7+/mo |
-| Google Imagen 4    | Highest fidelity           | No          | API           |
-| Seedream AI Studio | Multi-model (5.0/4.5/4.0)  | No          | Free / Paid   |
+| Generator           | Strength                  | Open Source | Pricing        |
+| ------------------- | ------------------------- | ----------- | -------------- |
+| Midjourney v7       | Artistic quality          | No          | $10-120/mo     |
+| FLUX 2              | Photorealism              | Yes         | Free / API     |
+| Stable Diffusion    | Full control              | Yes         | Free (OSS)     |
+| Ideogram v3         | Text rendering            | No          | Free / $7+/mo  |
+| Google Imagen 4     | Highest fidelity          | No          | API            |
+| Seedream AI Studio  | Multi-model (5.0/4.5/4.0) | No          | Free / Paid    |
 
 - [Adobe Firefly 3](https://firefly.adobe.com) - Generates commercially safe images from text prompts using a model trained exclusively on licensed data (🏷️ `Cloud` `Adobe CC` `Web`).
 - [DALL-E 3.5](https://openai.com/dall-e-3) - Generates detailed images from text prompts with 95% text accuracy integrated directly into ChatGPT (🏷️ `Cloud` `OpenAI` `API`).


### PR DESCRIPTION
## What

Adds [RustFox](https://github.com/chinkan/RustFox) to the **Local and Self-Hosted AI** section.

## Why RustFox Belongs Here

RustFox is an open-source (MIT), self-hosted Telegram AI assistant written in Rust. Unlike most AI assistants locked inside proprietary chat UIs, it lives in Telegram and acts as an agentic AI teammate with:

- **Sandboxed tool execution** — isolated filesystem, shell, and code execution
- **MCP server/client integration** — full Model Context Protocol support
- **Persistent memory** — vector search + embeddings for long-term recall
- **Scheduling** — cron-based and one-shot task execution
- **Multi-agent orchestration** — `invoke_agent`, `spawn_agents` with isolated agentic loops
- **BYOK** — bring your own keys, uses OpenRouter for model routing
- **Skills system** — hot-reloadable skill files for extending capabilities
- **Soul files** (SOUL.md, AGENTS.md, USER.md) — persistent personality and memory

## Checklist

- [x] Single sentence description with hyphen separator
- [x] Placed in alphabetical order (R after O, before v)
- [x] Links to GitHub repo
- [x] Includes relevant tags (Rust, Telegram, Self-Hosted, MCP, Sandbox)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added **RustFox** to “Local and Self-Hosted AI” with a capabilities-focused description (Telegram support, self-hosted deployment, MCP integration, sandboxed tool execution, persistent memory, scheduling, and multi-agent orchestration via OpenRouter), including its link.
  * Reformatted the image generation model table for improved alignment and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->