### PR TITLE
Add rust-norion to Safety Guardrails and Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Orchard Kit](https://github.com/OrchardHarmonics/orchard-kit) - Modules for agent runtime security, self-audit trails, and collective cognition patterns (🏷️ `Python` `Security` `SDK`).
 - [OWASP Top 10 for Agentic Apps](https://owasp.org/www-project-top-10-for-large-language-model-applications/) - Security framework covering goal hijacking, tool misuse, and cascading failure mitigations for agents (🏷️ `Policy` `Security` `Framework`).
 - [Rebuff](https://github.com/protectai/rebuff) - Self-hardening prompt injection detection system for securing agent inputs against adversarial attacks (🏷️ `Python` `Security` `SDK`).
+- [rust-norion](https://github.com/yanghao1143/rust-norion) - Rust prototype for AI runtime-control boundaries with routing, memory gates, evidence checks, rollback, and audit traces (🏷️ `Rust` `Runtime Control` `Prototype`).
 - [ai-evaluation](https://github.com/future-agi/ai-evaluation) - LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners (jailbreak, PII, injection) (🏷️ `Python` `Evaluation` `Guardrails` `SDK`).
 - [Future AGI](https://github.com/future-agi/future-agi) - Self-hostable end-to-end agent engineering platform with tracing, evals, guardrails, and gateway (🏷️ `Python` `Platform` `Self-hosted`).
 


### PR DESCRIPTION
Adds rust-norion to Safety Guardrails and Observability.

Why this fits:
- open-source Rust prototype focused on runtime-control boundaries around AI/agent workflows;
- relevant surfaces include routing, memory gates, evidence checks, rollback, and audit traces;
- description is one sentence and uses prototype wording.

Scope note: rust-norion is not a production inference engine or commercial gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry for **rust-norion** in the Safety Guardrails and Observability section.
  * Included a link and a brief overview of its Rust prototype capabilities, covering control boundaries, routing, memory gates, evidence checks, rollback, and audit traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->