### PR TITLE
Add Hermes to Voice Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Platforms for building, deploying, and scaling voice-based AI agents across call
 - [Bland AI](https://bland.ai/) - Automates outbound phone calls at scale with SOC2 and HIPAA compliance and CRM integration (🏷️ `Cloud` `Telephony` `API`).
 - [Deepgram](https://deepgram.com) - Sub-300ms speech-to-text and text-to-speech APIs purpose-built for real-time voice agent pipelines (🏷️ `Cloud` `STT/TTS` `API`).
 - [ElevenLabs](https://elevenlabs.io) - Industry-leading voice AI with 75ms latency, Conversational AI 2.0, RAG, and HIPAA compliance (🏷️ `Cloud` `Voice` `Platform`).
+- [Hermes](https://www.buildwithhermes.com) - White-label voice agent platform built for agencies, bundles native CRM, campaign orchestration, and transparent usage billing so one platform replaces the Retell plus GoHighLevel plus Zapier plus Stripe stack. From $149/mo (🏷️ `Cloud` `Agency` `Platform`).
 - [HeyGen](https://www.heygen.com) - Creates AI talking avatars with voice cloning and lip-sync for video-based agent interactions (🏷️ `Cloud` `Avatar` `Web`).
 - [PolyAI](https://poly.ai/en) - Enterprise voice AI platform for natural multi-turn conversations with high-volume call handling (🏷️ `Cloud` `Enterprise` `Platform`).
 - [Retell AI](https://www.retellai.com) - Builds human-like voice agents with multi-language telephony support and low-latency responses (🏷️ `Cloud` `Telephony` `API`).


### PR DESCRIPTION
Adds **Hermes** to the Voice Agent Platforms section.

Hermes is the operating platform for AI voice agencies. Unlike the API providers already listed (Retell, Vapi, Deepgram), it ships a full white-label stack: native CRM, campaign orchestration, telephony, and transparent usage billing under the agency's own brand, so a small team can deploy and scale client voice agents without duct-taping 5 to 7 separate tools. Entry placed alphabetically and formatted to match the existing table style with tags. Thanks for maintaining this list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Voice Agent Platforms” list with a new platform entry, including a link and descriptive tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->