### PR TITLE
Add Vestige to Memory and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [RAGFlow](https://github.com/infiniflow/ragflow) `🌱` `[Python]` `[RAG]` - Open-source RAG engine with agent capabilities and deep document understanding for knowledge bases.
 - [SimpleMem](https://github.com/aiming-lab/SimpleMem) `🌱` `[Python]` `[Multimodal]` - Efficient lifelong memory for LLM agents supporting both text and multimodal inputs.
 - [Supermemory](https://github.com/supermemoryai/supermemory) `🌱` `[TypeScript]` `[Vector DB]` - Extremely fast and scalable memory engine and API designed for the AI era.
+- [Vestige](https://github.com/samvallad33/vestige) `🌱` `[Rust]` `[MCP]` - Local-first memory server for coding agents with FSRS-6 retention, active forgetting, and correction tools.
 - [Weaviate](https://github.com/weaviate/weaviate) `🌱` `[Go]` `[Vector DB]` - Stores and searches vector embeddings with hybrid keyword and semantic retrieval for agent knowledge.
 - [Zep](https://github.com/getzep/zep) `🌱` `[Python]` `[Multi-Agent]` - Enriches agent long-term memory with automatic summarization, entity extraction, and search.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@
 - [RAGFlow](https://github.com/infiniflow/ragflow) `🌱` `[Python]` `[RAG]` - Open-source RAG engine with agent capabilities and deep document understanding for knowledge bases.
 - [SimpleMem](https://github.com/aiming-lab/SimpleMem) `🌱` `[Python]` `[Multimodal]` - Efficient lifelong memory for LLM agents supporting both text and multimodal inputs.
 - [Supermemory](https://github.com/supermemoryai/supermemory) `🌱` `[TypeScript]` `[Vector DB]` - Extremely fast and scalable memory engine and API designed for the AI era.
-- [Vestige](https://github.com/samvallad33/vestige) `🌱` `[Rust]` `[MCP]` - Local-first memory server for coding agents with FSRS-6 retention, active forgetting, and correction tools.
+- [Vestige](https://github.com/samvallad33/vestige) `🌱` `[Rust]` `[MCP]` - Provides local-first memory for coding agents with FSRS-6 retention, active forgetting, and correction tools.
 - [Weaviate](https://github.com/weaviate/weaviate) `🌱` `[Go]` `[Vector DB]` - Stores and searches vector embeddings with hybrid keyword and semantic retrieval for agent knowledge.
 - [Zep](https://github.com/getzep/zep) `🌱` `[Python]` `[Multi-Agent]` - Enriches agent long-term memory with automatic summarization, entity extraction, and search.
 


### PR DESCRIPTION
Adds Vestige to the Memory and Context section, in alphabetical order between Supermemory and Weaviate.

Entry follows the CONTRIBUTING format: tier badge, language tag, type tag, then a single-sentence description ending with a period.

- Tier: `🌱` Growing (around 565 GitHub stars, active commits).
- Language: `[Rust]` (single Rust binary).
- Type: `[MCP]` (MCP server for coding agents; MCP has priority in the type order).

Vestige is a local-first memory server for AI coding agents. It stores memory in local SQLite and exposes MCP tools for search, retrieval, correction, and lifecycle. It works with Claude Code, Cursor, VS Code, Codex, Windsurf, and JetBrains.

Checked: URL not already in the README, no em-dash, alphabetical order within the category, and the compact format. Pre-existing awesome-lint findings on other lines are unrelated to this entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Memory and Context” entry for Vestige, linking to the project and describing it as a local-first memory solution for coding agents.
  * Included a brief overview of its retention, active forgetting, and correction capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->