### PR TITLE
Add AgentsCoin MCP to MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 ### MCP (Model Context Protocol)
 
 - [A2A Protocol](https://github.com/a2aproject/A2A) `🚀` `[Python]` `[Multi-Agent]` - Google's open protocol enabling AI agents to communicate, collaborate, and delegate tasks across frameworks.
+- [AgentsCoin MCP](https://github.com/axiosdevs/agentscoin-mcp) `🚀` `[TypeScript]` `[Web3]` - Gives an AI agent its own money on a live EVM chain (chainId 24368): wallet, faucet, send, create/trade tokens. Remote MCP at https://agents-coin.com/mcp.
 - [Arcade AI](https://github.com/ArcadeAI/arcade-mcp) `🌱` `[Python]` `[Multi-Agent]` - Tool-use platform with authentication, authorization, and logging for agent-tool interactions.
 - [Composio](https://github.com/ComposioHQ/composio) `🌱` `[TypeScript]` `[Multi-Agent]` - Integration platform with 250+ pre-built tool connectors for AI agents and LLMs.
 - [Docker MCP](https://github.com/docker/mcp-gateway) `🌱` `[Go]` `[MCP]` - Docker's MCP gateway CLI plugin for running MCP servers in isolated containers.

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 ### MCP (Model Context Protocol)
 
 - [A2A Protocol](https://github.com/a2aproject/A2A) `🚀` `[Python]` `[Multi-Agent]` - Google's open protocol enabling AI agents to communicate, collaborate, and delegate tasks across frameworks.
-- [AgentsCoin MCP](https://github.com/axiosdevs/agentscoin-mcp) `🚀` `[TypeScript]` `[Web3]` - Gives an AI agent its own money on a live EVM chain (chainId 24368): wallet, faucet, send, create/trade tokens. Remote MCP at https://agents-coin.com/mcp.
+- [AgentsCoin MCP](https://github.com/axiosdevs/agentscoin-mcp) `🌱` `[TypeScript]` `[MCP]` - Gives an AI agent its own wallet and money on a live EVM chain to send, create, and trade tokens.
 - [Arcade AI](https://github.com/ArcadeAI/arcade-mcp) `🌱` `[Python]` `[Multi-Agent]` - Tool-use platform with authentication, authorization, and logging for agent-tool interactions.
 - [Composio](https://github.com/ComposioHQ/composio) `🌱` `[TypeScript]` `[Multi-Agent]` - Integration platform with 250+ pre-built tool connectors for AI agents and LLMs.
 - [Docker MCP](https://github.com/docker/mcp-gateway) `🌱` `[Go]` `[MCP]` - Docker's MCP gateway CLI plugin for running MCP servers in isolated containers.


### PR DESCRIPTION
Adds **AgentsCoin MCP** to the MCP (Model Context Protocol) section, placed alphabetically.

AgentsCoin gives an AI agent its own money on a live EVM chain (chainId 24368) via an MCP server: create a wallet, get coins from a faucet, send, and create/trade tokens. Remote MCP available at https://agents-coin.com/mcp (npm: `agentscoin-mcp`).

One entry, following the existing `status` / `language` / `category` backtick-tag format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry under the “MCP (Model Context Protocol)” section for **AgentsCoin MCP**, including its repository link, technology tags, and a brief description of providing an AI agent with wallet access plus token creation/sending and trading capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->