### PR TITLE
Add BuyWhere to Sales and Outreach Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ AI agents that automate customer support, CRM workflows, sales outreach, and tic
 ### Sales and Outreach Agents
 
 - [Apollo.io](https://www.apollo.io) `🌱` `[Cloud]` `[Multi-Agent]` - AI prospecting platform with 275M+ contacts, lead scoring, and automated email sequencing.
-- [BuyWhere](https://buywhere.ai) `🌱` `[Cloud]` `[MCP]` - AI shopping agent for real-time product search and price comparison across 11M+ products in SG/SEA/US markets. MCP-native server with 8 tools for search, deals, comparison, and affiliate links.
+- [BuyWhere](https://buywhere.ai) `🌱` `[Cloud]` `[MCP]` - AI shopping agent for real-time product search and price comparison across SG/SEA/US markets using an MCP-native server with 8 tools.
 - [Clay](https://www.clay.com) `🌱` `[Cloud]` `[IDE]` - Enriches leads from 70+ data providers and generates hyper-personalized outreach at scale.
 - [Instantly](https://instantly.ai) `🌱` `[Cloud]` `[Multi-Agent]` - Generates AI cold emails with smart sender rotation and built-in domain warmup for deliverability.
 - [Lavender](https://www.lavender.ai) `🌱` `[Cloud]` `[Multi-Agent]` - Coaches email writing in real-time with AI response scoring and recipient intelligence.

--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ AI agents that automate customer support, CRM workflows, sales outreach, and tic
 ### Sales and Outreach Agents
 
 - [Apollo.io](https://www.apollo.io) `🌱` `[Cloud]` `[Multi-Agent]` - AI prospecting platform with 275M+ contacts, lead scoring, and automated email sequencing.
+- [BuyWhere](https://buywhere.ai) `🌱` `[Cloud]` `[MCP]` - AI shopping agent for real-time product search and price comparison across 11M+ products in SG/SEA/US markets. MCP-native server with 8 tools for search, deals, comparison, and affiliate links.
 - [Clay](https://www.clay.com) `🌱` `[Cloud]` `[IDE]` - Enriches leads from 70+ data providers and generates hyper-personalized outreach at scale.
 - [Instantly](https://instantly.ai) `🌱` `[Cloud]` `[Multi-Agent]` - Generates AI cold emails with smart sender rotation and built-in domain warmup for deliverability.
 - [Lavender](https://www.lavender.ai) `🌱` `[Cloud]` `[Multi-Agent]` - Coaches email writing in real-time with AI response scoring and recipient intelligence.


### PR DESCRIPTION
## What

Adds [BuyWhere](https://buywhere.ai) to the **Sales and Outreach Agents** section (alphabetical order, between Apollo.io and Clay).

## Entry

```markdown
- [BuyWhere](https://buywhere.ai) 🌱 [Cloud] [MCP] - AI shopping agent for real-time product search and price comparison across 11M+ products in SG/SEA/US markets. MCP-native server with 8 tools for search, deals, comparison, and affiliate links.
```

## Why it fits

BuyWhere is an AI shopping agent that enables sales and outreach teams to discover and compare products across 200+ retailers in real-time:

- **MCP-native**: `npx @buywhere/mcp-server` — works with Claude, Cursor, Windsurf, and any MCP client
- **8 tools**: search_products, get_deals, get_product_details, compare_prices, get_affiliate_link, get_catalog, get_price, get_merchant_info
- **11M+ live products** across Singapore, SEA, and US markets
- **Published**: npm `@buywhere/mcp-server`, MCP Registry, Glama, Smithery, mcp.so

Thanks for maintaining this excellent list! 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new entry highlighting **BuyWhere** as an AI shopping agent with real-time product search and price comparison.
  * Noted that it is **MCP-native** and includes **8 tools**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->