### PR TITLE
Add OpenHuman to Agent Interfaces and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Frontend workspaces and chat interfaces with built-in agent plugins and tool-use
 - [LibreChat](https://github.com/danny-avila/LibreChat) `🌱` `[TypeScript]` `[IDE]` - Self-hosted multi-model chat interface supporting all major AI providers with access control.
 - [LobeHub](https://lobehub.com/) `🌱` `[TypeScript]` `[Multi-Agent]` - Modern platform for hybrid work and AI-driven collaboration with extensible agent teams and rapid integration.
 - [LobeChat](https://github.com/lobehub/lobehub) `🌱` `[TypeScript]` `[Multi-Agent]` - Modern, open-source AI chat framework with a massive plugin ecosystem for autonomous agent capabilities.
+- [OpenHuman](https://github.com/tinyhumansai/openhuman) `🚀` `[Rust]` `[Memory]` - Self-hosted local-first personal AI assistant with a Rust core, desktop apps, knowledge-graph memory, skills, voice, and multi-channel messaging.
 - [OpenWebUI](https://github.com/open-webui/open-webui) `🌱` `[TypeScript]` `[RAG]` - Extensible local AI interface with built-in RAG, tool use, and support for multi-agent workflows.
 
 ## Agent Deployment and Hosting


### PR DESCRIPTION
Adds **OpenHuman** to Agent Interfaces and UIs.

OpenHuman is an open-source, self-hosted personal AI assistant: a cross-platform desktop app (Windows, macOS, Linux) built on a Rust core, with a knowledge-graph memory, skills, voice, multi-channel messaging, and local or cloud LLM routing. It fits alongside the other self-hosted agent interfaces in this category (AnythingLLM, LibreChat, OpenWebUI).

- Repo: https://github.com/tinyhumansai/openhuman (open source, ~33k stars, actively maintained)
- Entry follows the compact format: `🚀` tier (33k+ stars), `[Rust]` (primary language), `[Memory]` (its defining capability).
- Placed alphabetically in Agent Interfaces and UIs; URL is not a duplicate; no em dashes.

Disclosure: I'm affiliated with TinyHumans, the maker of OpenHuman.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry under “Agent Interfaces and UIs” for OpenHuman, including its repository link and topic tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->