### PR TITLE
Add RustFox to Local and Self-Hosted AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ Tools for running LLMs locally and self-hosting AI agent platforms with full pri
 - [LM Studio](https://lmstudio.ai) `🌱` `[TypeScript]` `[Local]` - Desktop application for running local LLMs with a polished UI across all major platforms.
 - [LocalAI](https://github.com/mudler/LocalAI) `🚀` `[Go]` `[OpenAI]` - Drop-in OpenAI API replacement that runs models locally without requiring a GPU.
 - [Ollama](https://github.com/ollama/ollama) `🚀` `[Go]` `[GitHub]` - Run LLMs locally with a dead-simple CLI interface and 162K+ GitHub stars.
+- [RustFox](https://github.com/chinkan/RustFox) `🔬` `[Rust]` `[MCP]` - Self-hosted Telegram AI assistant written in Rust with sandboxed tool execution, MCP integration, persistent memory, scheduling, and multi-agent orchestration via OpenRouterGitHub stars.
 - [vLLM](https://github.com/vllm-project/vllm) `🚀` `[Python]` `[Local]` - High-throughput LLM serving engine with PagedAttention for production-grade local inference.
 - [Yao Agents](https://github.com/YaoApp/yao) `🌱` `[Go]` `[MCP]` - Local-first AI execution platform with Docker sandbox isolation, BYOK model configuration, MCP support, 5-stage Pipeline, and multi-platform messaging via WeChat, Feishu, DingTalk, Telegram, and Discord.
 

--- a/README.md
+++ b/README.md
@@ -735,7 +735,7 @@ Tools for running LLMs locally and self-hosting AI agent platforms with full pri
 - [LM Studio](https://lmstudio.ai) `🌱` `[TypeScript]` `[Local]` - Desktop application for running local LLMs with a polished UI across all major platforms.
 - [LocalAI](https://github.com/mudler/LocalAI) `🚀` `[Go]` `[OpenAI]` - Drop-in OpenAI API replacement that runs models locally without requiring a GPU.
 - [Ollama](https://github.com/ollama/ollama) `🚀` `[Go]` `[GitHub]` - Run LLMs locally with a dead-simple CLI interface and 162K+ GitHub stars.
-- [RustFox](https://github.com/chinkan/RustFox) `🔬` `[Rust]` `[MCP]` - Self-hosted Telegram AI assistant written in Rust with sandboxed tool execution, MCP integration, persistent memory, scheduling, and multi-agent orchestration via OpenRouterGitHub stars.
+- [RustFox](https://github.com/chinkan/RustFox) `🔬` `[Rust]` `[MCP]` - Self-hosted Telegram AI assistant written in Rust with sandboxed tool execution, MCP integration, and multi-agent orchestration.
 - [vLLM](https://github.com/vllm-project/vllm) `🚀` `[Python]` `[Local]` - High-throughput LLM serving engine with PagedAttention for production-grade local inference.
 - [Yao Agents](https://github.com/YaoApp/yao) `🌱` `[Go]` `[MCP]` - Local-first AI execution platform with Docker sandbox isolation, BYOK model configuration, MCP support, 5-stage Pipeline, and multi-platform messaging via WeChat, Feishu, DingTalk, Telegram, and Discord.
 


### PR DESCRIPTION
## What does this PR do?

<!-- Check all that apply -->

- [x] Adds a new tool
- [ ] Updates an existing entry (stars, links, description)
- [ ] Removes an abandoned / dead project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting
- [ ] Other: ___

---

## For new tool additions

**Tool name:** RustFox
**Category it belongs in:** Local and Self-Hosted AI
**GitHub URL:** https://github.com/chinkan/RustFox
**Site URL (if any):** N/A

### Why does this tool belong on the list?

RustFox is an open-source (MIT), self-hosted Telegram AI assistant written in Rust. Unlike most AI assistants locked inside proprietary chat UIs, it lives in Telegram and acts as an agentic AI teammate with:

- **Sandboxed tool execution** — isolated filesystem, shell, and code execution
- **MCP server/client integration** — full Model Context Protocol support
- **Persistent memory** — vector search + embeddings for long-term recall
- **Scheduling** — cron-based and one-shot task execution
- **Multi-agent orchestration** — `invoke_agent`, `spawn_agents` with isolated agentic loops
- **BYOK** — bring your own keys, uses OpenRouter for model routing
- **Skills system** — hot-reloadable skill files for extending capabilities
- **Soul files** (SOUL.md, AGENTS.md, USER.md) — persistent personality and memory

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months**
- [x] This tool is **meaningfully different** from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the [format in CONTRIBUTING.md](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents/Contributing.md) exactly
- [x] The entry is placed in **alphabetical order** within its section
- [x] All links open correctly and go to the right place
- [x] Description is exactly **two sentences** — no promotional language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new RustFox listing under **Local and Self-Hosted AI**, including its repository link, tag badges, and a brief description of its self-hosted Telegram AI assistant capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->