### PR TITLE
Add Superdense to Memory and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@
 - [Qdrant](https://github.com/qdrant/qdrant) `🌱` `[Rust]` `[Vector DB]` - High-performance vector similarity search engine with rich payload filtering for agent memory.
 - [RAGFlow](https://github.com/infiniflow/ragflow) `🌱` `[Python]` `[RAG]` - Open-source RAG engine with agent capabilities and deep document understanding for knowledge bases.
 - [SimpleMem](https://github.com/aiming-lab/SimpleMem) `🌱` `[Python]` `[Multimodal]` - Efficient lifelong memory for LLM agents supporting both text and multimodal inputs.
+- [Superdense](https://github.com/Nimrobo/superdense) `🔬` `[TypeScript]` `[Memory]` - Gives coding agents persistent memory of what worked across sessions, tracked against real-world outcomes.
 - [Supermemory](https://github.com/supermemoryai/supermemory) `🌱` `[TypeScript]` `[Vector DB]` - Extremely fast and scalable memory engine and API designed for the AI era.
 - [Vestige](https://github.com/samvallad33/vestige) `🌱` `[Rust]` `[MCP]` - Provides local-first memory for coding agents with FSRS-6 retention, active forgetting, and correction tools.
 - [Weaviate](https://github.com/weaviate/weaviate) `🌱` `[Go]` `[Vector DB]` - Stores and searches vector embeddings with hybrid keyword and semantic retrieval for agent knowledge.


### PR DESCRIPTION
Adds [Superdense](https://github.com/Nimrobo/superdense) to the Memory and Context section, alongside Kage and Mori — it's a local outcome-loop and reward layer that gives coding agents persistent memory of what worked across sessions, tracked against real-world outcomes, rather than a vector DB or RAG pipeline.

- npm package: `@nimrobo/superdense`, TypeScript, local-only (no cloud)
- Docs: https://nimroboai.com
- ~73 GitHub stars — tagged `🔬` (Emerging) per your tier criteria

Followed the entry format exactly: tier + language + type tags, one factual sentence, alphabetical placement (between SimpleMem and Supermemory).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Memory and Context” section with a new tool entry for **Superdense**.
  * Added the associated tags: **🔬**, **TypeScript**, and **Memory**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->