### PR TITLE
Add Dark-Moon to Cybersecurity Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,7 +756,7 @@ Frameworks and tools for AI risk management, regulatory compliance, and governan
 
 AI agents specialized in penetration testing, vulnerability discovery, threat detection, and security analysis.
 
-- [Dark-Moon](https://github.com/ASCIT31/Dark-Moon) `🌱` `[CLI]` `[Security]` - Autonomous AI penetration testing platform where Markdown playbooks orchestrate 80+ offensive tools via MCP across web, cloud, Active Directory, Kubernetes and API targets.
+- [Dark-Moon](https://github.com/ASCIT31/Dark-Moon) `🌱` `[Python]` `[MCP]` - Autonomous AI penetration testing platform orchestrating 80+ offensive tools via MCP across web, cloud, Active Directory, Kubernetes, and API targets.
 - [Microsoft Security Copilot](https://www.microsoft.com/en-us/security/business/ai-machine-learning/microsoft-security-copilot) `🚀` `[Cloud]` `[Microsoft]` - Enterprise threat detection and incident response AI integrated across Microsoft security products.
 - [PentestGPT](https://github.com/GreyDGL/PentestGPT) `🌱` `[Python]` `[CLI]` - GPT-powered penetration testing tool with automated reasoning for vulnerability assessment.
 - [YAWNING TITAN](https://github.com/dstl/YAWNING-TITAN) `🌱` `[Python]` `[Graph-Based]` - Graph-based cybersecurity simulation environment for training and testing defensive AI agents.

--- a/README.md
+++ b/README.md
@@ -756,6 +756,7 @@ Frameworks and tools for AI risk management, regulatory compliance, and governan
 
 AI agents specialized in penetration testing, vulnerability discovery, threat detection, and security analysis.
 
+- [Dark-Moon](https://github.com/ASCIT31/Dark-Moon) `🌱` `[CLI]` `[Security]` - Autonomous AI penetration testing platform where Markdown playbooks orchestrate 80+ offensive tools via MCP across web, cloud, Active Directory, Kubernetes and API targets.
 - [Microsoft Security Copilot](https://www.microsoft.com/en-us/security/business/ai-machine-learning/microsoft-security-copilot) `🚀` `[Cloud]` `[Microsoft]` - Enterprise threat detection and incident response AI integrated across Microsoft security products.
 - [PentestGPT](https://github.com/GreyDGL/PentestGPT) `🌱` `[Python]` `[CLI]` - GPT-powered penetration testing tool with automated reasoning for vulnerability assessment.
 - [YAWNING TITAN](https://github.com/dstl/YAWNING-TITAN) `🌱` `[Python]` `[Graph-Based]` - Graph-based cybersecurity simulation environment for training and testing defensive AI agents.


### PR DESCRIPTION
Dark-Moon is an open source (GPL-3.0) autonomous penetration testing platform where Markdown methodology playbooks orchestrate 80+ offensive tools through MCP. Added to the Cybersecurity Agents section. https://github.com/ASCIT31/Dark-Moon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the cybersecurity agents list with a new entry for **Dark-Moon**.
  * Added a brief description of its capabilities across web, cloud, Active Directory, Kubernetes, and API targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->