### PR TITLE
Add Pluribus to Safety Guardrails and Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [NeMo Guardrails](https://github.com/NVIDIA-NeMo/Guardrails) `🌱` `[Python]` `[Multi-Agent]` - NVIDIA programmable guardrails toolkit for controlling and securing LLM-powered agent conversations.
 - [Orchard Kit](https://github.com/OrchardHarmonics/orchard-kit) `🌱` `[Python]` `[Security]` - Modules for agent runtime security, self-audit trails, and collective cognition patterns.
 - [OWASP Top 10 for Agentic Apps](https://owasp.org/www-project-top-10-for-large-language-model-applications/) `🌱` `[Python]` `[Security]` - Security framework covering goal hijacking, tool misuse, and cascading failure mitigations for agents.
+- [Pluribus](https://github.com/caioribeiroclw-pixel/pluribus) `🔬` `[TypeScript]` `[Observability]` - Generates cross-tool agent context and privacy-safe evidence receipts for loaded authority, handoffs, and skill use.
 - [Rebuff](https://github.com/protectai/rebuff) `🌱` `[Python]` `[Security]` - Self-hardening prompt injection detection system for securing agent inputs against adversarial attacks.
 - [ai-evaluation](https://github.com/future-agi/ai-evaluation) `🌱` `[Python]` `[Evaluation]` - LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners (jailbreak, PII, injection).
 - [Future AGI](https://github.com/future-agi/future-agi) `🌱` `[Python]` `[Self-Hosted]` - Self-hostable end-to-end agent engineering platform with tracing, evals, guardrails, and gateway.


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool
- [ ] Updates an existing entry (stars, links, description)
- [ ] Removes an abandoned / dead project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting
- [ ] Other: ___

---

## For new tool additions

**Tool name:** Pluribus
**Category it belongs in:** Safety Guardrails and Observability
**GitHub URL:** https://github.com/caioribeiroclw-pixel/pluribus
**Site URL (if any):** https://caioribeiroclw-pixel.github.io/pluribus/boundary-receipt-gallery.html

### Why does this tool belong on the list?

Pluribus is a Node CLI for cross-tool agent context plus privacy-safe boundary receipts that record hashes and outcomes without raw prompts, local paths, or tool output. The receipt approach has been independently implemented and reviewed in `sfrangulov/skill-graveyard#11`, where it records observed skill invocation while leaving downstream impact explicitly unknown.

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months**
- [x] This tool is **meaningfully different** from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the format in CONTRIBUTING.md exactly
- [x] The entry is placed in **alphabetical order** within its section
- [x] All links open correctly and go to the right place
- [ ] Description is exactly **two sentences** — no promotional language

Note: CONTRIBUTING.md requires a one-sentence entry, while the PR template asks for two. I followed CONTRIBUTING.md for the list entry.

---

## Anything else?

Validation:

- `git diff --check` passed
- Project URL returned HTTP 200
- `npx awesome-lint` reaches the repository-level topic checks, then reports that the upstream repository lacks the `awesome` and `awesome-list` GitHub topics; this PR does not change repository settings

Independent implementation evidence: https://github.com/sfrangulov/skill-graveyard/pull/11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Pluribus to the Safety Guardrails and Observability listings.
  * Included its GitHub link, technology tags, and a brief description of its cross-tool agent context and privacy-safe evidence receipts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->