### PR TITLE
Add Eigendark Agent MCP to communication protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [Arcade AI](https://github.com/ArcadeAI/arcade-mcp) `🌱` `[Python]` `[Multi-Agent]` - Tool-use platform with authentication, authorization, and logging for agent-tool interactions.
 - [Composio](https://github.com/ComposioHQ/composio) `🌱` `[TypeScript]` `[Multi-Agent]` - Integration platform with 250+ pre-built tool connectors for AI agents and LLMs.
 - [Docker MCP](https://github.com/docker/mcp-gateway) `🌱` `[Go]` `[MCP]` - Docker's MCP gateway CLI plugin for running MCP servers in isolated containers.
+- [Eigendark Agent MCP](https://github.com/kai-linux/eigendark-agent-mcp) `🔬` `[Python]` `[MCP]` - Self-onboards AI agents to play matches, submit legal actions, and publish collectible-card-game replays.
 - [HCS Agent Protocol](https://github.com/hashgraph/hedera-agent-kit-js) `🌱` `[TypeScript]` `[IDE]` - Hedera open standards for agent identity with trustless P2P communication and 187K+ verified agents.
 - [HIG Doctor](https://github.com/raintree-technology/hig-doctor) `🌱` `[TypeScript]` `[MCP]` - Apple HIG audit CLI and MCP server exposing design-guideline lookup and project audits for coding agents across SwiftUI, UIKit, React, Next.js, Flutter, Compose, HTML, and CSS.
 - [Hyper](https://github.com/hyperfx-ai/marketing-skills) `🌱` `[Cloud]` `[MCP]` - Open-source Agent Skills and a hosted MCP connecting agents to 200+ marketing integrations across paid ads, SEO, analytics, social, and image and video generation, with a human-approval gate on every action.


### PR DESCRIPTION
## Summary

- add Eigendark Agent MCP to the MCP protocol implementations section
- classify it as an emerging Python MCP server
- describe its self-onboarding, gameplay, and replay surface factually

## Verification

- repository URL returns HTTP 200
- `git diff --check` passes
- entry is alphabetized and follows the documented compact format
- `awesome-lint README.md` reaches the repo-level `awesome-github` check; it reports that the fork is not a valid canonical awesome-list repository, with no line-level entry errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Eigendark Agent MCP to the list of supported Model Context Protocol servers.
  * Documented capabilities for AI agents to join matches, submit legal actions, and publish collectible card game replays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->