### PR TITLE
Add Agon to Deep Research Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ AI platforms that conduct autonomous multi-step research, synthesize findings fr
 | Gemini Research  | 1M tokens      | Google Search + KG          |
 | Perplexity Pro   | Variable       | Real-time cited search      |
 
+- [Agon](https://github.com/AutoResearch-Factory/Agon) `🔬` `[Python]` `[Multi-Agent]` - Omnidisciplinary autonomous research system that replaces one-off prompts with Prompt Economy's reusable loops.
 - [CAJAL](https://github.com/Agnuxo1/CAJAL) `🌱` `[Python]` `[Local]` - Local AI agent that generates publication-ready IMRaD scientific papers with verified arXiv citations and AI tribunal scoring.
 - [ChatGPT Deep Research](https://openai.com/index/introducing-deep-research) `🚀` `[Cloud]` `[OpenAI]` - Conducts extended reasoning with web browsing to produce structured research reports with Canvas output.
 - [Claude Deep Research](https://www.anthropic.com/research) `🚀` `[Cloud]` `[Anthropic]` - Performs multi-step investigation with verified source citations and 200K token context window.


### PR DESCRIPTION
Splitting the earlier bundled PR (#152, closed) per your request for individual PRs. This one adds Agon: an omnidisciplinary autonomous research system built on Prompt Economy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Agon to the “Deep Research Agents” tool list, including its link and tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->