### PR TITLE
Add autonomous research survey to Learning Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Curated list of vertical agent solutions for finance, healthcare, legal, manufac
 - [ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629) `🌱` `[Python]` `[Paper]` - The foundational paper behind the ReAct prompting pattern used in most agent frameworks.
 - [Reflexion](https://github.com/noahshinn/reflexion) `🌱` `[Python]` `[Paper]` - Research framework letting agents learn from past mistakes via iterative verbal self-reflection loops.
 - [Tree of Thoughts](https://github.com/princeton-nlp/tree-of-thought-llm) `🌱` `[Python]` `[Paper]` - Explores multiple parallel reasoning paths before committing to a final answer for complex problems.
+- [What's Missing in Autonomous Research?](https://haizhaoyang.github.io/research/autoresearch-survey.html) `🔬` `[Python]` `[Research]` - Systematizes 56 autonomous research systems across seven axes; most can generate research artifacts but few can defend them before publication.
 
 ## Agent Communication
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Curated list of vertical agent solutions for finance, healthcare, legal, manufac
 - [ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629) `🌱` `[Python]` `[Paper]` - The foundational paper behind the ReAct prompting pattern used in most agent frameworks.
 - [Reflexion](https://github.com/noahshinn/reflexion) `🌱` `[Python]` `[Paper]` - Research framework letting agents learn from past mistakes via iterative verbal self-reflection loops.
 - [Tree of Thoughts](https://github.com/princeton-nlp/tree-of-thought-llm) `🌱` `[Python]` `[Paper]` - Explores multiple parallel reasoning paths before committing to a final answer for complex problems.
-- [What's Missing in Autonomous Research?](https://haizhaoyang.github.io/research/autoresearch-survey.html) `🔬` `[Python]` `[Research]` - Systematizes 56 autonomous research systems across seven axes; most can generate research artifacts but few can defend them before publication.
+- [What's Missing in Autonomous Research?](https://haizhaoyang.github.io/research/autoresearch-survey.html) `🔬` `[Python]` `[Research]` - Systematizes 56 autonomous research systems across seven axes, showing most can generate but few can defend research artifacts.
 
 ## Agent Communication
 


### PR DESCRIPTION
Splitting the earlier bundled PR (#152, closed) per your request for individual PRs. This one adds "What's Missing in Autonomous Research?", a systematization of 56 autonomous research systems. Also incorporates CodeRabbit's suggestion to place it in Learning Resources rather than Deep Research Agents, since it's a survey rather than a research-executing platform.