### PR TITLE
Add OpenAgentRelay to Agent Tooling and Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [LlamaParse](https://github.com/run-llama/llama_cloud_services) `🌱` `[Python]` `[RAG]` - GenAI-native document parser designed to extract complex tables and layouts for RAG pipelines.
 - [Marker](https://github.com/datalab-to/marker) `🌱` `[Python]` `[CLI]` - Converts PDF documents to markdown with high accuracy for tables, equations, and figures.
 - [Notte](https://github.com/nottelabs/notte) `🚀` `[Python]` `[Pipeline]` - Browser automation engine optimized for production AI pipelines.
+- [OpenAgentRelay](https://github.com/ShakespeareLabs/open-agent-relay) `🔬` `[Python]` `[CLI]` - Exposes existing local agents and automations as trusted-LAN capabilities callable by teammates or other agents.
 - [Pilot Protocol](https://github.com/TeoSlayer/pilotprotocol) `🌱` `[Go]` `[Multi-Agent]` - Networking stack for distributed agent systems with encrypted tunnels.
 - [Playwright](https://github.com/microsoft/playwright) `🌱` `[TypeScript]` `[Testing]` - Automates Chromium, Firefox, and WebKit browsers with a single cross-language API for agent-driven testing.
 - [ScrapeGraphAI](https://github.com/ScrapeGraphAI/Scrapegraph-ai) `🌱` `[Python]` `[LangChain]` - Python web-scraping library that uses LLMs to build intelligent scraping pipelines from natural-language instructions.


### PR DESCRIPTION
Adds OpenAgentRelay to **Agent Tooling and Infrastructure** in alphabetical order.

The entry follows the required compact format with the Emerging tier, Python language, CLI type, and a single factual sentence. OpenAgentRelay is actively maintained, Apache-2.0 licensed, publicly available, and directly supports agent-to-agent/team capability sharing over a trusted LAN.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenAgentRelay to the list of agent tooling and infrastructure resources.
  * Documented its ability to expose local agents and automations for trusted-LAN access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->