### PR TITLE
Add AgentServices — x402 paid data APIs for AI agents (54 services, 37 MCP tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Agent Bounties](https://github.com/NSPG13/agent-bounties) `🔬` `[Rust]` `[MCP]` - Coordinates verifiable digital bounty workflows designed for agents to post, fund, claim, solve, verify, and earn.
 - [AgentDock](https://github.com/agentdock/agentdock) `🚀` `[Python]` `[Docker]` - Framework for building and deploying production-ready AI agents with composable node architecture.
 - [Agent Starter](https://github.com/raintree-technology/agent-starter) `🌱` `[TypeScript]` `[MCP]` - Project-local config manager that syncs one `agent.json` manifest into Claude Code, Codex, Cursor, and MCP setup while preserving manual edits and detecting drift.
+- [AgentServices](https://agentservices.to) `🚀` `[Python]` `[x402]` - Paid data APIs for AI agents with 54 services, 37 MCP tools, and x402 nanopayments on Base. Market data, onchain analytics, AI inference, and research.
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) `🚀` `[Python]` `[OpenAI]` - Bash CLI for switching OpenAI Codex CLI and Desktop profiles with isolated CODEX_HOME directories.
 - [Crawl4AI](https://github.com/unclecode/crawl4ai) `🌱` `[Python]` `[Multi-Agent]` - Extracts structured data from web pages using LLM-friendly output formats optimized for agent ingestion.
 - [Docling](https://github.com/docling-project/docling) `🌱` `[Python]` `[IDE]` - Parses PDFs, DOCX, and slides into structured text with deep layout understanding for document agents.


### PR DESCRIPTION
## AgentServices — Paid Data APIs for AI Agents

Adding **AgentServices** to the **Agent Tooling and Infrastructure** section.

### What it is
AgentServices ([agentservices.to](https://agentservices.to)) provides paid data APIs designed specifically for AI agents, using the x402 payment protocol for per-call nanopayments on Base (USDC).

### Key stats
- **54 services** across market data, onchain analytics, AI inference, and research
- **37 MCP tools** (official MCP server, protocol 2026-07-28)
- **41 x402-paid endpoints** — agents pay per-call via HTTP 402 → USDC settlement
- **On official MCP Registry**: `to.agentservices/agentservices` (v5.3.0)
- **OpenAPI-first**: Full schema at `agentservices.to/openapi.json` with `x-payment-info` extensions

### Why it belongs here
AgentServices sits in the infrastructure layer — agents need data, they pay for it per-call without API keys or billing setup. This is the x402 payment protocol in production for agent-to-service transactions.

### Entry added
Placed alphabetically in **Agent Tooling and Infrastructure** (between Agent Starter and codex-profiles).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AgentServices to the Agent Tooling and Infrastructure documentation.
  * Documented its paid data APIs, available services, MCP tools, and x402 nanopayments on Base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->