### PR TITLE
Add VibeKit.bot to Prompt-to-App Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,7 @@ Platforms that generate full-stack applications, components, or web apps from na
 - [PlayCode Agent](https://playcode.io) `🌱` `[Cloud]` `[Multi-Agent]` - Browser-only lightweight web app creation tool with AI-assisted code generation.
 - [Replit Agent](https://replit.com/agent4) `🌱` `[Cloud]` `[Multi-Agent]` - Builds and deploys full-stack projects from prompts with integrated hosting and collaboration.
 - [v0 by Vercel](https://v0.app) `🚀` `[Cloud]` `[CLI]` - Generates React and Tailwind UI components from text descriptions with one-click Vercel deployment.
+- [VibeKit.bot](https://vibekit.bot) `🔬` `[Cloud]` `[Stateful]` - Builds and hosts full-stack apps from phone chat, with a persistent per-app agent and BYOK keys.
 
 ## Multi-Agent Consumer Platforms
 


### PR DESCRIPTION
Adds **VibeKit.bot** to `## Prompt-to-App Builders`, alphabetized after v0 by Vercel.

```markdown
- [VibeKit.bot](https://vibekit.bot) `🔬` `[Cloud]` `[Stateful]` - Builds and hosts full-stack apps from phone chat, with a persistent per-app agent and BYOK keys.
```

**Why it fits this section:** it takes a natural-language prompt and produces a running full-stack app, like the existing entries. What's different from Bolt/Lovable/Replit Agent is that the agent is persistent and per-app: it keeps running after the build, so you can chat with it to change, debug, or redeploy the app later, from a phone. Apps are hosted by VibeKit at `<name>.vibekit.bot` with optional Postgres, logs, and env vars. Users can bring their own Anthropic or OpenAI key at no markup, or use a free model tier.

**Tags, per CONTRIBUTING:**
- `🔬` — recently launched hosted product, so Emerging rather than Growing.
- `[Cloud]` — fully managed SaaS, no local runtime.
- `[Stateful]` — the persistent per-app agent (with its own workspace and memory) is the defining architecture; MCP is only a peripheral integration, so it would overstate it.
- Description is one sentence, 16 words, no promotional language.

**Checks:** live public product, actively maintained, not already in the README (verified `vibekit` appears nowhere), URL unique.

Disclosure: I'm a maintainer of VibeKit.bot. Naming it "VibeKit.bot" to disambiguate from the unrelated `superagent-ai/vibekit` SDK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added VibeKit.bot to the Prompt-to-App Builders list.
  * Included descriptions and relevant badges highlighting its cloud-based, stateful capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->