### PR TITLE
Add Shipmoor to Safety Guardrails and Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [OWASP Top 10 for Agentic Apps](https://owasp.org/www-project-top-10-for-large-language-model-applications/) `🌱` `[Python]` `[Security]` - Security framework covering goal hijacking, tool misuse, and cascading failure mitigations for agents.
 - [Pluribus](https://github.com/caioribeiroclw-pixel/pluribus) `🔬` `[TypeScript]` `[Observability]` - Generates cross-tool agent context and privacy-safe evidence receipts for loaded authority, handoffs, and skill use.
 - [Rebuff](https://github.com/protectai/rebuff) `🌱` `[Python]` `[Security]` - Self-hardening prompt injection detection system for securing agent inputs against adversarial attacks.
+- [Shipmoor](https://shipmoor.dev) `🔬` `[Python]` `[Testing]` - Local, deterministic verification layer for AI-agent code: scans, test evidence, and a binding merge verdict without uploading source.
 - [ai-evaluation](https://github.com/future-agi/ai-evaluation) `🌱` `[Python]` `[Evaluation]` - LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners (jailbreak, PII, injection).
 - [Future AGI](https://github.com/future-agi/future-agi) `🌱` `[Python]` `[Self-Hosted]` - Self-hostable end-to-end agent engineering platform with tracing, evals, guardrails, and gateway.
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [OWASP Top 10 for Agentic Apps](https://owasp.org/www-project-top-10-for-large-language-model-applications/) `🌱` `[Python]` `[Security]` - Security framework covering goal hijacking, tool misuse, and cascading failure mitigations for agents.
 - [Pluribus](https://github.com/caioribeiroclw-pixel/pluribus) `🔬` `[TypeScript]` `[Observability]` - Generates cross-tool agent context and privacy-safe evidence receipts for loaded authority, handoffs, and skill use.
 - [Rebuff](https://github.com/protectai/rebuff) `🌱` `[Python]` `[Security]` - Self-hardening prompt injection detection system for securing agent inputs against adversarial attacks.
-- [Shipmoor](https://shipmoor.dev) `🔬` `[Python]` `[Testing]` - Local, deterministic verification layer for AI-agent code: scans, test evidence, and a binding merge verdict without uploading source.
+- [Shipmoor](https://shipmoor.dev) `🔬` `[Python]` `[Testing]` - Local, deterministic verification layer for AI agent code: scans, test evidence, and a binding merge verdict without uploading source.
 - [ai-evaluation](https://github.com/future-agi/ai-evaluation) `🌱` `[Python]` `[Evaluation]` - LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners (jailbreak, PII, injection).
 - [Future AGI](https://github.com/future-agi/future-agi) `🌱` `[Python]` `[Self-Hosted]` - Self-hostable end-to-end agent engineering platform with tracing, evals, guardrails, and gateway.
 


### PR DESCRIPTION
Adds Shipmoor, a local verification layer for AI-agent-written code (deterministic scan, test evidence, and a binding merge verdict - no source upload). Tagged `🔬` (Emerging) since it's a young project (0 GitHub stars on its public repos, launched ~2 months ago): happy for maintainers to adjust the tier per the review criteria in CONTRIBUTING.md.

- Website: https://shipmoor.dev
- Language tag `Python`: confirmed from the public install script, which unpacks a PyInstaller bundle.
- Type tag `Testing`: it verifies whether agent-written tests actually passed rather than trusting a bare exit code (Test Evidence), and gates on a deterministic floor rather than a model's opinion.

Followed the canonical entry format from CONTRIBUTING.md, inserted alphabetically after Rebuff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Shipmoor to the Safety Guardrails and Observability tools list.
  * Described its local, deterministic AI-agent code verification capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->