### PR TITLE
Add Find MCP to Agent Communication Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [Arcade AI](https://github.com/ArcadeAI/arcade-mcp) `🌱` `[Python]` `[Multi-Agent]` - Tool-use platform with authentication, authorization, and logging for agent-tool interactions.
 - [Composio](https://github.com/ComposioHQ/composio) `🌱` `[TypeScript]` `[Multi-Agent]` - Integration platform with 250+ pre-built tool connectors for AI agents and LLMs.
 - [Docker MCP](https://github.com/docker/mcp-gateway) `🌱` `[Go]` `[MCP]` - Docker's MCP gateway CLI plugin for running MCP servers in isolated containers.
+- [Find MCP](https://github.com/agentage/find-mcp) `🌱` `[TypeScript]` `[MCP]` - Search 17,000+ MCP servers from the official registry via remote Streamable HTTP or local stdio.
 - [HCS Agent Protocol](https://github.com/hashgraph/hedera-agent-kit-js) `🌱` `[TypeScript]` `[IDE]` - Hedera open standards for agent identity with trustless P2P communication and 187K+ verified agents.
 - [HIG Doctor](https://github.com/raintree-technology/hig-doctor) `🌱` `[TypeScript]` `[MCP]` - Apple HIG audit CLI and MCP server exposing design-guideline lookup and project audits for coding agents across SwiftUI, UIKit, React, Next.js, Flutter, Compose, HTML, and CSS.
 - [Hyper](https://github.com/hyperfx-ai/marketing-skills) `🌱` `[Cloud]` `[MCP]` - Open-source Agent Skills and a hosted MCP connecting agents to 200+ marketing integrations across paid ads, SEO, analytics, social, and image and video generation, with a human-approval gate on every action.


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool

---

## For new tool additions

**Tool name:** Find MCP
**Category it belongs in:** Agent Communication Protocols -> MCP (Model Context Protocol)
**GitHub URL:** https://github.com/agentage/find-mcp
**Site URL (if any):** https://catalog.agentage.io/mcp

### Why does this tool belong on the list?

Find MCP is an MCP server for discovering other MCP servers - it searches the agentage MCP Catalog (17,000+ servers synced from the official MCP registry, registry.modelcontextprotocol.io) via tools `mcp_search`, `mcp_get`, `mcp_categories`. Works as a remote Streamable HTTP server (`https://catalog.agentage.io/mcp`, no auth for search) or via stdio (`npx -y @agentage/find-mcp`); official registry entry `io.agentage/find-mcp`.

### Pre-submission checklist

- [x] The repo has had a commit in the last 6 months
- [x] This tool is meaningfully different from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the format in CONTRIBUTING.md exactly
- [x] The entry is placed in alphabetical order within its section
- [x] All links open correctly and go to the right place
- [ ] Description is exactly two sentences - no promotional language

Note: entry description is one sentence (12-18 words), matching the compact-format examples and word-count rule in CONTRIBUTING.md's "Description" section - leaving the "two sentences" box unchecked since it appears to be a stale carryover from an older format.

---

## Anything else?

Disclosure: I maintain Find MCP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Find MCP to the MCP tool list.
  * Highlighted support for searching more than 17,000 MCP servers through remote or local connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->