### PR TITLE
Add The Agents Index to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,10 +799,10 @@ Curated newsletters, podcasts, and communities for staying current with AI agent
 - [r/ClaudeAI](https://www.reddit.com/r/ClaudeAI/) `🌱` `[Python]` `[Multi-Agent]` - Reddit community for Claude users sharing agent workflows, prompts, and integration patterns.
 - [r/LangChain](https://www.reddit.com/r/LangChain/) `🌱` `[Python]` `[LangChain]` - Reddit community for agent developers using LangChain, LangGraph, and related frameworks.
 - [r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/) `🌱` `[Cloud]` `[IDE]` - Reddit community for self-hosted LLM users sharing local deployment and agent setup guides.
+- [The Agents Index](https://theagentsindex.com) `🔬` `[Cloud]` `[Multi-Agent]` - Compares AI agent tools with sourced pricing, verdicts, and pros/cons in a researched, quality-gated directory.
 - [The Rundown AI](https://www.therundown.ai) `🌱` `[Python]` `[RAG]` - Daily AI digest reaching 600K+ subscribers with concise coverage of agent news and launches.
 
 - [Agents Launchpad](https://launchpad.smartbizcalc.com) `🌱` `[Python]` `[Multi-Agent]` - Community-curated directory of indie AI agents and tools.
-- [The Agents Index](https://theagentsindex.com) `🔬` `[Cloud]` `[Multi-Agent]` - Compares AI agent tools with sourced pricing, verdicts, and pros/cons in a researched, quality-gated directory.
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for the full update history.

--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ Curated newsletters, podcasts, and communities for staying current with AI agent
 - [The Rundown AI](https://www.therundown.ai) `🌱` `[Python]` `[RAG]` - Daily AI digest reaching 600K+ subscribers with concise coverage of agent news and launches.
 
 - [Agents Launchpad](https://launchpad.smartbizcalc.com) `🌱` `[Python]` `[Multi-Agent]` - Community-curated directory of indie AI agents and tools.
+- [The Agents Index](https://theagentsindex.com) `🔬` `[Cloud]` `[Multi-Agent]` - Compares AI agent tools with sourced pricing, verdicts, and pros/cons in a researched, quality-gated directory.
 ## Changelog
 
 See [CHANGELOG.md](CHANGELOG.md) for the full update history.


### PR DESCRIPTION
Adds **The Agents Index** (https://theagentsindex.com) to the *Newsletters and Communities* section, next to the other directory-style entry (Agents Launchpad).

The Agents Index is a researched directory of AI agent tools (coding agents, frameworks, voice/browser agents, etc.) — 30 listings as of this PR, each with sourced pricing, a written verdict, and honest pros/cons, gated by an internal quality checklist before publishing (no auto-generated/templated entries). It launched 2026-07-13, so I tagged it `🔬` Emerging per the tier criteria (recently launched, no GitHub-star signal since it's a hosted product, not a repo).

Tags: `[Cloud]` (fully managed hosted product, no local runtime) and `[Multi-Agent]` (matching the tag already used for the section's other directory-type entries, AiToolsObserver and Agents Launchpad, since "Directory" isn't in the type list).

Happy to adjust tier/tags/placement if you'd prefer it elsewhere — thanks for maintaining this list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added **The Agents Index** to the “Newsletters and Communities” directory, including its link, tags, and a description of its researched, quality-gated comparison of AI agent tools (with sourced pricing and pros/cons).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->