### PR TITLE
Add verdict4 to Agent Evaluation and Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Frontend workspaces and chat interfaces with built-in agent plugins and tool-use
 - [GAIA Benchmark](https://huggingface.co/papers/2311.12983) `🌱` `[Python]` `[Benchmark]` - Benchmark for General AI Assistants measuring real-world reasoning and tool use.
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) `🌱` `[Python]` `[Evaluation]` - Framework for evaluating large language models with composable tasks and scoring.
 - [SWE-bench](https://github.com/SWE-bench/SWE-bench) `🚀` `[Python]` `[GitHub]` - Benchmark for evaluating LLMs on real-world software engineering tasks from GitHub issues.
+- [verdict4](https://github.com/MetaCortex-Dynamics/verdict4) `🌱` `[Python]` `[Evaluation]` - Four-value evaluation (NO/YES/MAYBE/IFF) and loop runner replacing boolean pass/fail in agent loops. Zero dependencies.
 - [WebArena](https://github.com/web-arena-x/webarena) `🌱` `[Python]` `[Evaluation]` - Benchmark for web agent evaluation using real websites with realistic task completion metrics.
 
 ## Agent Testing & Debugging


### PR DESCRIPTION
**Disclosure:** I am affiliated with MetaCortex Dynamics, the author of this project. This is a self-submission.

Adds verdict4 — a four-value evaluation primitive (NO/YES/MAYBE/IFF) + loop runner for agent loops. Zero dependencies, MIT-licensed.

Install (not yet on PyPI): `pip install git+https://github.com/MetaCortex-Dynamics/verdict4.git@v0.1.0`

If it is not a fit for this list, no worries — feel free to close.