### PR TITLE
add-intelica-veradata-trustboost

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [E2B](https://github.com/e2b-dev/e2b) `🌱` `[TypeScript]` `[Multi-Agent]` - Cloud sandboxes for AI agents to run code securely in isolated environments.
 - [Engram](https://github.com/kwstx/translator) `🌱` `[Python]` `[Multi-Agent]` - Universal bridge for multi-protocol AI agent systems with automated semantic mapping.
 - [Firecrawl](https://github.com/firecrawl/firecrawl) `🌱` `[TypeScript]` `[Multi-Agent]` - Web scraping API built for LLMs that converts websites to clean, structured markdown.
+- [Intelica](https://github.com/teodorofodocrispin-cmyk/Intelica-docs) `🌱` `[Python]` `[x402]` - Competitive intelligence API for AI agents providing structured moat scoring, competitor mapping, and market entry analysis benchmarked against an accumulated competitive graph.
 - [Jina Reader](https://github.com/jina-ai/reader) `🌱` `[TypeScript]` `[Multi-Agent]` - Converts any URL to LLM-ready clean text via a simple API prefix for agent ingestion.
 - [LlamaParse](https://github.com/run-llama/llama_cloud_services) `🌱` `[Python]` `[RAG]` - GenAI-native document parser designed to extract complex tables and layouts for RAG pipelines.
 - [Marker](https://github.com/datalab-to/marker) `🌱` `[Python]` `[CLI]` - Converts PDF documents to markdown with high accuracy for tables, equations, and figures.
@@ -235,6 +236,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Surya](https://github.com/datalab-to/surya) `🌱` `[Python]` `[CLI]` - Runs OCR and layout detection on documents in 90+ languages for multilingual document agents.
 - [Tavily](https://github.com/tavily-ai/tavily-python) `🌱` `[Python]` `[Multi-Agent]` - Search API purpose-built for LLM agents providing real-time, accurate web data with source citations.
 - [traceAI](https://github.com/future-agi/traceAI) `🌱` `[Python]` `[Observability]` - OpenTelemetry-native tracing for LLM and agent apps with 50+ framework integrations.
+- [TrustBoost](https://github.com/teodorofodocrispin-cmyk/trustboost-api) `🌱` `[Python]` `[x402]` - PII sanitization firewall for AI agent pipelines that redacts sensitive identifiers before content reaches an LLM with on-chain proof of sanitization.
 - [Unstructured](https://github.com/Unstructured-IO/unstructured) `🌱` `[Python]` `[Pipeline]` - Ingests and preprocesses documents across 25+ file types for downstream LLM and agent pipelines.
 
 ## Low and No-Code Builders
@@ -764,6 +766,7 @@ Frameworks and tools for AI risk management, regulatory compliance, and governan
 - [NIST AI RMF](https://airc.nist.gov/) `🌱` `[Python]` `[Multi-Agent]` - US framework for AI risk management covering Govern, Map, Measure, and Manage functions.
 - [OneTrust AI Governance](https://www.onetrust.com/solutions/ai-governance/) `🌱` `[Cloud]` `[Compliance]` - Risk classification, consent management, and compliance workflows for AI agent deployments.
 - [Project Glasswing](https://www.anthropic.com/glasswing) `🌱` `[Python]` `[Benchmark]` - Industry consortium (11-company initiative) focused on AI safety, red-teaming, and shared benchmarks for agent risk mitigation.
+- [VeraData](https://github.com/teodorofodocrispin-cmyk/veradata-public) `🌱` `[Python]` `[x402]` - LATAM compliance API providing sanctions screening, KYB for five countries, and an EU AI Act compliant audit hash on every response.
 
 ## Cybersecurity Agents
 


### PR DESCRIPTION
## What does this PR do?
- [x] Adds a new tool

---

## For new tool additions

**Tool name:** Intelica, VeraData, TrustBoost (3 related x402-native APIs from the same independent builder)

**Category it belongs in:**
- Intelica → Agent Tooling and Infrastructure
- TrustBoost → Agent Tooling and Infrastructure
- VeraData → AI Governance and Compliance

**GitHub URL:**
- https://github.com/teodorofodocrispin-cmyk/Intelica-docs
- https://github.com/teodorofodocrispin-cmyk/veradata-public
- https://github.com/teodorofodocrispin-cmyk/trustboost-api

**Site URL (if any):**
- https://api.intelica.dev
- https://api.veradata.dev
- https://api.trustboost.dev

### Why does this tool belong on the list?

Three independent, production x402-native APIs built for autonomous agents, each solving a distinct problem not yet covered by other entries. Intelica gives agents structured competitive intelligence (moat scoring, competitor mapping) benchmarked against a 3,600+ company graph. TrustBoost sanitizes PII from text before it reaches an LLM, with on-chain proof of sanitization. VeraData provides LATAM sanctions/KYB screening with an independently-verified EU AI Act Art.12 audit hash chain. All three are pay-per-call via x402 (no subscription), expose MCP servers, and are already listed in punkpeye/awesome-mcp-servers and xpaysh/awesome-x402.

### Pre-submission checklist
- [x] The repo has had a commit in the last 6 months
- [x] This tool is meaningfully different from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the format in CONTRIBUTING.md exactly
- [x] The entry is placed in alphabetical order within its section
- [x] All links open correctly and go to the right place
- [x] Description is exactly two sentences — no promotional language

---

## Anything else?

Related prior submission: issue #118 (Intelica) was closed as "completed" without the entry actually landing in README.md — opening this PR directly to close that loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s curated lists by adding **Intelica** and **TrustBoost** under “Agent Tooling and Infrastructure.”
  * Added **VeraData** under “AI Governance and Compliance.”
  * Each new entry includes a link and category tags describing its intended role, including competitive intelligence/market analysis, PII sanitization with proof, and LATAM compliance with sanctions screening/KYB and EU AI Act audit hashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->