### PR TITLE
Add Juggler to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@
 - [GitHub Copilot](https://github.com/features/copilot) `🌱` `[TypeScript]` `[VS Code]` - Agent Mode in VS Code with Copilot Workspace for issue-to-PR workflows across Claude, GPT, and Gemini.
 - [Goose](https://github.com/aaif-goose/goose) `🌱` `[Rust]` `[CLI]` - Extensible open-source CLI agent that installs, executes, edits, and tests with any LLM.
 - [JetBrains AI](https://www.jetbrains.com/ai/) `🌱` `[Kotlin]` `[JetBrains]` - Deep AI integration across all JetBrains IDEs with context-aware completions and refactoring.
-- [Juggler](https://github.com/juggler-ai/juggler) `🌱` `[JavaScript]` `[Desktop]` - A multi-client desktop/remote GUI agent with inspectable tool calls, branching-thread editable context, fully extensible via plugins.
+- [Juggler](https://github.com/juggler-ai/juggler) `🌱` `[Desktop]` `[Local]` - Multi-client desktop/remote GUI agent with inspectable tool calls, branching-thread editable context, and plugin extensibility.
 - [Kiro](https://kiro.dev) `🚀` `[Cloud]` `[IDE]` - Spec-driven development agent that writes specs, auto-generates tasks, implements code, and automates DevOps workflows.
 - [Open Interpreter](https://github.com/openinterpreter/open-interpreter) `🌱` `[Python]` `[CLI]` - Execute code locally via natural-language model instructions with a ChatGPT-like interface.
 - [opencode](https://github.com/anomalyco/opencode) `🌱` `[TypeScript]` `[Desktop]` - Open-source coding agent available as a desktop app with a visual interface.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 - [GitHub Copilot](https://github.com/features/copilot) `🌱` `[TypeScript]` `[VS Code]` - Agent Mode in VS Code with Copilot Workspace for issue-to-PR workflows across Claude, GPT, and Gemini.
 - [Goose](https://github.com/aaif-goose/goose) `🌱` `[Rust]` `[CLI]` - Extensible open-source CLI agent that installs, executes, edits, and tests with any LLM.
 - [JetBrains AI](https://www.jetbrains.com/ai/) `🌱` `[Kotlin]` `[JetBrains]` - Deep AI integration across all JetBrains IDEs with context-aware completions and refactoring.
+- [Juggler](https://github.com/juggler-ai/juggler) `🌱` `[JavaScript]` `[Desktop]` - A multi-client desktop/remote GUI agent with inspectable tool calls, branching-thread editable context, fully extensible via plugins.
 - [Kiro](https://kiro.dev) `🚀` `[Cloud]` `[IDE]` - Spec-driven development agent that writes specs, auto-generates tasks, implements code, and automates DevOps workflows.
 - [Open Interpreter](https://github.com/openinterpreter/open-interpreter) `🌱` `[Python]` `[CLI]` - Execute code locally via natural-language model instructions with a ChatGPT-like interface.
 - [opencode](https://github.com/anomalyco/opencode) `🌱` `[TypeScript]` `[Desktop]` - Open-source coding agent available as a desktop app with a visual interface.


### PR DESCRIPTION
Adds **Juggler** to the **Coding Agents** section, in alphabetical order (between JetBrains AI and Kiro).

- [Juggler](https://github.com/juggler-ai/juggler) `🌱` `[JavaScript]` `[Desktop]` - A multi-client desktop/remote GUI agent with inspectable tool calls, branching-thread editable context, fully extensible via plugins.

Follows CONTRIBUTING.md:
- Compact format: tier badge + `[Language]` + `[Type]` + one-sentence description.
- **Tier `🌱` Growing** — ~512 GitHub stars, actively maintained (commits this week).
- **Language `[JavaScript]`** — GitHub's reported primary language.
- **Type `[Desktop]`** — native desktop GUI app (also runs in the browser).
- Single sentence, hyphen-space separator (no em-dash), no promotional language.
- URL is not a duplicate; alphabetical ordering preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added **Juggler** to the list of supported coding agents.
  * Documented its JavaScript-based desktop/remote GUI, inspectable tool calls, editable branching-thread context, and plugin extensibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->