### PR TITLE
Add lucinate to Agent Interfaces and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Frontend workspaces and chat interfaces with built-in agent plugins and tool-use
 - [OpenHuman](https://github.com/tinyhumansai/openhuman) `🚀` `[Rust]` `[Memory]` - Self-hosted local-first personal AI assistant with a Rust core, desktop apps, knowledge-graph memory, skills, voice, and multi-channel messaging.
 - [Orkas](https://github.com/Orkas-AI/Orkas) `🔬` `[Desktop]` `[Multi-Agent]` - Runs parallel AI agents in a local-first desktop workspace with shared files, BYOK providers, and optional sync.
 - [OpenWebUI](https://github.com/open-webui/open-webui) `🌱` `[TypeScript]` `[RAG]` - Extensible local AI interface with built-in RAG, tool use, and support for multi-agent workflows.
+- [lucinate](https://github.com/lucinate-ai/lucinate) `🌱` `[Go]` `[TUI]` - Multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible APIs with routines, multi-agent switching, and local agent skills.
 
 ## Agent Deployment and Hosting
 


### PR DESCRIPTION
### Add [lucinate](https://github.com/lucinate-ai/lucinate)

A terminal-native AI chat client supporting OpenClaw, Hermes, Ollama, and any OpenAI-compatible backend — with routines, multi-agent switching, tool call cards, and local agent skills, all in the TUI.

**Why it fits:** lucinate fills the TUI gap in the Agent Interfaces section, offering a terminal-based alternative to the desktop and web UIs already listed.

- Apache 2.0 licensed, actively maintained (v1.23.0)
- Cross-platform: Linux, macOS, Windows
- Added at bottom of section per guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added lucinate to the list of agent interfaces and UIs.
  * Documented support for multiple AI backends, routines, and local agent skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->