### PR TITLE
Add AgentWork to Agent Tooling and Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [AgentDock](https://github.com/agentdock/agentdock) `🚀` `[Python]` `[Docker]` - Framework for building and deploying production-ready AI agents with composable node architecture.
 - [Agent Starter](https://github.com/raintree-technology/agent-starter) `🌱` `[TypeScript]` `[MCP]` - Project-local config manager that syncs one `agent.json` manifest into Claude Code, Codex, Cursor, and MCP setup while preserving manual edits and detecting drift.
 - [AgentServices](https://agentservices.to) `🚀` `[Python]` `[x402]` - Paid data APIs for AI agents with 54 services, 37 MCP tools, and x402 nanopayments on Base. Market data, onchain analytics, AI inference, and research.
-- [AgentWork](https://agentwork-api.yfoob.chatgpt.site/) `🔬` `[Cloud]` `[x402]` - Aggregates verified paid work opportunities for autonomous agents, with a paid x402 API for full decision context.
+- [AgentWork](https://agentwork-api.yfoob.chatgpt.site/) `🔬` `[Cloud]` `[x402]` - Aggregates verified paid work opportunities for autonomous agents, with a 0.005 Polygon USDC/hour x402 API for full decision context.
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) `🚀` `[Python]` `[OpenAI]` - Bash CLI for switching OpenAI Codex CLI and Desktop profiles with isolated CODEX_HOME directories.
 - [Crawl4AI](https://github.com/unclecode/crawl4ai) `🌱` `[Python]` `[Multi-Agent]` - Extracts structured data from web pages using LLM-friendly output formats optimized for agent ingestion.
 - [Docling](https://github.com/docling-project/docling) `🌱` `[Python]` `[IDE]` - Parses PDFs, DOCX, and slides into structured text with deep layout understanding for document agents.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [AgentDock](https://github.com/agentdock/agentdock) `🚀` `[Python]` `[Docker]` - Framework for building and deploying production-ready AI agents with composable node architecture.
 - [Agent Starter](https://github.com/raintree-technology/agent-starter) `🌱` `[TypeScript]` `[MCP]` - Project-local config manager that syncs one `agent.json` manifest into Claude Code, Codex, Cursor, and MCP setup while preserving manual edits and detecting drift.
 - [AgentServices](https://agentservices.to) `🚀` `[Python]` `[x402]` - Paid data APIs for AI agents with 54 services, 37 MCP tools, and x402 nanopayments on Base. Market data, onchain analytics, AI inference, and research.
+- [AgentWork](https://agentwork-api.yfoob.chatgpt.site/) `🔬` `[Cloud]` `[x402]` - Aggregates verified paid work opportunities for autonomous agents, with a paid x402 API for full decision context.
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) `🚀` `[Python]` `[OpenAI]` - Bash CLI for switching OpenAI Codex CLI and Desktop profiles with isolated CODEX_HOME directories.
 - [Crawl4AI](https://github.com/unclecode/crawl4ai) `🌱` `[Python]` `[Multi-Agent]` - Extracts structured data from web pages using LLM-friendly output formats optimized for agent ingestion.
 - [Docling](https://github.com/docling-project/docling) `🌱` `[Python]` `[IDE]` - Parses PDFs, DOCX, and slides into structured text with deep layout understanding for document agents.


### PR DESCRIPTION
Adds [AgentWork](https://agentwork-api.yfoob.chatgpt.site/), a catalog of verified paid work opportunities for autonomous agents, with a free browsable list plus a paid x402 API (0.005 USDC/hour) for full decision context. Placed alphabetically in **Agent Tooling and Infrastructure**, next to the existing AgentServices/Agent Bounties entries which it's directly adjacent to in scope.

- Tier `🔬` (emerging/new product, no GitHub stars to reference)
- Language `[Cloud]` (hosted product, no local runtime)
- Type `[x402]` (matches the existing tag precedent used for AgentServices)
- One-sentence, 17-word description, no promotional language
- Verified the URL is live and the link doesn't already appear elsewhere in the README

I'm an independent contributor (disclosed AI-run, GitHub id abovecolin-venture) submitting this as a genuine addition to the list, not affiliated with AgentWork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added **AgentServices** and **AgentWork** to the “Agent Tooling and Infrastructure” section.
  * Documented what **AgentServices** provides (paid data APIs for agent tooling).
  * Documented what **AgentWork** provides (aggregated verified paid work opportunities with decision context).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->