### PR TITLE
Add whatbroke to Agent Evaluation and Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ Frontend workspaces and chat interfaces with built-in agent plugins and tool-use
 - [Inspect AI](https://github.com/UKGovernmentBEIS/inspect_ai) `🌱` `[Python]` `[Evaluation]` - Framework for evaluating large language models with composable tasks and scoring.
 - [SWE-bench](https://github.com/SWE-bench/SWE-bench) `🚀` `[Python]` `[GitHub]` - Benchmark for evaluating LLMs on real-world software engineering tasks from GitHub issues.
 - [WebArena](https://github.com/web-arena-x/webarena) `🌱` `[Python]` `[Evaluation]` - Benchmark for web agent evaluation using real websites with realistic task completion metrics.
+- [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) `🔬` `[TypeScript]` `[Testing]` - CLI that diffs an AI agent's behavior between two runs, comparing tool calls, args, cost, latency, and outcome flips.
 
 ## Agent Testing & Debugging
 


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool
- [ ] Updates an existing entry (stars, links, description)
- [ ] Removes an abandoned / dead project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting
- [ ] Other: ___

---

## For new tool additions

**Tool name:** whatbroke
**Category it belongs in:** Agent Evaluation and Benchmarks
**GitHub URL:** https://github.com/arthi-arumugam-git/whatbroke
**Site URL (if any):** https://www.npmjs.com/package/whatbroke-cli

### Why does this tool belong on the list?

whatbroke is a CLI that diffs two agent runs and reports what changed: tool calls, order, args, cost, latency, and outcome flips, plus flake detection across repeats. The listed entries are benchmarks and eval frameworks; this covers the run-to-run regression angle, comparing the same agent before and after a prompt or model change. I built it, MIT licensed, TypeScript.

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months**
- [x] This tool is **meaningfully different** from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the [format in CONTRIBUTING.md](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents/Contributing.md) exactly
- [x] The entry is placed in **alphabetical order** within its section
- [x] All links open correctly and go to the right place
- [ ] Description is exactly **two sentences**: no promotional language

---

## Anything else?

I kept the description to one sentence with no promotional language, since the compact format in CONTRIBUTING.md and every existing entry in the section use one sentence. Happy to expand to two if you prefer the template rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
 * Added **whatbroke** to the Agent Evaluation and Benchmarks list.
 * Described it as a CLI for comparing AI agent runs, including tool calls, arguments, cost, latency, and outcome changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
