### PR TITLE
Add OutreachAgent to Sales and Outreach Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ AI agents that automate customer support, CRM workflows, sales outreach, and tic
 - [Clay](https://www.clay.com) `🌱` `[Cloud]` `[IDE]` - Enriches leads from 70+ data providers and generates hyper-personalized outreach at scale.
 - [Instantly](https://instantly.ai) `🌱` `[Cloud]` `[Multi-Agent]` - Generates AI cold emails with smart sender rotation and built-in domain warmup for deliverability.
 - [Lavender](https://lavender.ai/) `🌱` `[Cloud]` `[Multi-Agent]` - Coaches email writing in real-time with AI response scoring and recipient intelligence.
+- [OutreachAgent](https://outreachagent.dev/for-agents) `🔬` `[Cloud]` `[Event-Driven]` - Runs reply-aware outbound email workflows with webhooks, sender pacing, approvals, and deliverability guardrails.
 - [Overloop CLI](https://overloop.com) `🌱` `[Cloud]` `[CLI]` - AI outbound CLI agent that sources 450M+ contacts and runs email plus LinkedIn campaigns with JSON output.
 
 ## Voice Agent Platforms


### PR DESCRIPTION
## Summary

- Add OutreachAgent to **Customer Support and CRM Agents → Sales and Outreach Agents**.
- Describe its reply-aware outbound email workflows, webhooks, sender pacing, approvals, and deliverability guardrails.
- Use the required compact format and alphabetical placement.

## Validation

- Verified the linked agent page is public and documents the listed capabilities.
- Confirmed the name and URL do not already appear in the README.
- Ran `npx --yes awesome-lint README.md` successfully.
- Intentionally made no MCP or Python-package claim because those install paths are not currently public.

## Disclosure

I maintain OutreachAgent and may benefit from its inclusion. The proposed entry is a single neutral line and makes no performance or adoption claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `OutreachAgent` to the Sales and Outreach Agents list in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->