### PR TITLE
Add AgentPump to Industry-Specific Agents > Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ Curated list of vertical agent solutions for finance, healthcare, legal, manufac
 - [JPMorgan AlphaBlue](https://www.jpmorgan.com/global) `🚀` `[Cloud]` `[Multi-Agent]` - Trading and market analysis agent integrations for institutional workflows.
 - [Goldman Sachs Marquee AI](https://www.goldmansachs.com) `🚀` `[Cloud]` `[Multi-Agent]` - Market data and analytics agents built on Marquee platform.
 - [Morgan Stanley AdvisorBot](https://www.morganstanley.com) `🚀` `[Cloud]` `[CLI]` - Financial advisory assistant for advisors and retail clients.
+- [AgentPump](https://agentpump.app) `🔬` `[Cloud]` `[CLI]` - Runs autonomous on-chain memecoin trading agents on Solana that trade on a schedule, operable from the terminal via the @agentpump/cli.
+
 
 ### Healthcare
 


### PR DESCRIPTION
Adds **AgentPump** to Industry-Specific Agents > Finance.

AgentPump runs autonomous on-chain memecoin trading agents on Solana: you fund a persona-driven agent and it trades on a schedule. It is operable end-to-end from the terminal via the published npm CLI `@agentpump/cli`, with a machine-readable OpenAPI spec and llms.txt for agents.

- Site: https://agentpump.app
- CLI: https://www.npmjs.com/package/@agentpump/cli
- API: https://agentpump.app/openapi.json · Agent docs: https://agentpump.app/llms.txt

Entry follows the compact format: tier `🔬` (recently launched), `[Cloud]` `[CLI]` tags, action-verb description, no promotional language.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AgentPump to the Finance industry section.
  * Described its Solana-based memecoin trading platform and terminal CLI access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->