### PR TITLE
Add Workforce Wave to Voice Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,7 @@ Platforms for building, deploying, and scaling voice-based AI agents across call
 - [Synthesia](https://www.synthesia.io) `🌱` `[Cloud]` `[IDE]` - Generates AI video avatars that speak in 120+ languages for training and communication agents.
 - [Synthflow](https://synthflow.ai) `🌱` `[Cloud]` `[No-Code]` - No-code voice agent builder with pre-built templates for SMBs to deploy phone agents quickly.
 - [Voiceflow](https://www.voiceflow.com) `🌱` `[Cloud]` `[No-Code]` - No-code builder for voice and chat agents with visual conversation design and team collaboration.
+- [Workforce Wave](https://www.workforcewave.com/) `🔬` `[Cloud]` `[Voice]` - AI voice receptionist for SMBs handling 24/7 call answering, appointment booking, and lead capture.
 
 ## Deep Research Agents
 


### PR DESCRIPTION
Adds Workforce Wave, an AI voice receptionist for SMBs (24/7 call answering, appointment booking, lead capture), to the Voice Agent Platforms list alongside comparable entries (Bland AI, Synthflow, Retell AI, Voiceflow). Follows the entry format and tier guidance in CONTRIBUTING.md (🔬 Emerging tier).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Workforce Wave to the Voice Agent Platforms section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->