### PR TITLE
Add Open Index to Memory and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@
 - [Milvus](https://github.com/milvus-io/milvus) `🌱` `[Go]` `[Vector DB]` - Scales vector search to billions of embeddings for large-scale agent knowledge bases.
 - [Mori (森)](https://github.com/fjwood69/mori) `🌱` `[Python]` `[MCP]` - Sovereign shared memory layer for AI coding agents with zero-instrumentation capture via lifecycle hooks, a dream pipeline that distills sessions into curated governed memories, and support for Claude Code, Cursor, Codex, and Antigravity.
 - [Motorhead](https://github.com/getmetal/motorhead) `🌱` `[Rust]` `[Multi-Agent]` - Manages conversation context windows for agents with automatic background summarization.
+- [Open Index](https://github.com/DrDroidLab/open-index) `🔬` `[Python]` `[MCP]` - Builds typed knowledge graphs with hybrid search and read/write MCP tools for domain-specific agents.
 - [Pathway](https://github.com/pathwaycom/pathway) `🌱` `[Python]` `[RAG]` - Live data RAG engine with real-time streaming for agents that need up-to-the-second knowledge.
 - [Pinecone](https://www.pinecone.io) `🚀` `[Cloud]` `[Vector DB]` - Managed vector database with agent namespaces for multi-tenant isolation, hybrid search (vector + keyword), serverless auto-scaling, and $11B valuation.
 - [Qdrant](https://github.com/qdrant/qdrant) `🌱` `[Rust]` `[Vector DB]` - High-performance vector similarity search engine with rich payload filtering for agent memory.


### PR DESCRIPTION
## Summary

Adds Open Index alphabetically under **Memory and Context** using the required compact format.

The entry uses the Emerging tier because the project is new and currently below 500 stars, Python as its primary language, and MCP as the highest-priority applicable type.

- [x] Directly related to AI agents
- [x] Updated within the last six months
- [x] Publicly available and MIT licensed
- [x] Functional implementation with documentation and tests
- [x] Not already listed

Disclosure: this is an affiliated submission from the Open Index team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Open Index to the Memory and Context tools list.
  * Included a link and overview of its typed knowledge graphs, hybrid search, and read/write tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->