### PR TITLE
Add Ouroboros to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Agent Bounties](https://github.com/NSPG13/agent-bounties) `🔬` `[Rust]` `[MCP]` - Coordinates verifiable digital bounty workflows designed for agents to post, fund, claim, solve, verify, and earn.
 - [AgentDock](https://github.com/agentdock/agentdock) `🚀` `[Python]` `[Docker]` - Framework for building and deploying production-ready AI agents with composable node architecture.
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) `🚀` `[Python]` `[OpenAI]` - Bash CLI for switching OpenAI Codex CLI and Desktop profiles with isolated CODEX_HOME directories.
-- [Agent Island](https://github.com/tristan666666/agent-island) `🚀` `[Swift]` `[Observability]` - Menu bar and notch companion showing live session state and your-turn alerts for Claude Code, Codex, Gemini, Grok and Cursor, with quota and cost computed locally.
 - [CompozyOS](https://github.com/compozy/compozy) `🚀` `[Go]` `[Multi-Agent]` - Runs agent CLIs as a team on loops and schedules, with shared memory, permissions and approvals in one self-hosted daemon.
 - [Crawl4AI](https://github.com/unclecode/crawl4ai) `🌱` `[Python]` `[Multi-Agent]` - Extracts structured data from web pages using LLM-friendly output formats optimized for agent ingestion.
 - [Docling](https://github.com/docling-project/docling) `🌱` `[Python]` `[IDE]` - Parses PDFs, DOCX, and slides into structured text with deep layout understanding for document agents.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@
 - [Open Interpreter](https://github.com/openinterpreter/openinterpreter) `🌱` `[Python]` `[CLI]` - Execute code locally via natural-language model instructions with a ChatGPT-like interface.
 - [opencode](https://github.com/anomalyco/opencode) `🌱` `[TypeScript]` `[Desktop]` - Open-source coding agent available as a desktop app with a visual interface.
 - [OpenHands](https://github.com/OpenHands/OpenHands) `🌱` `[Python]` `[Docker]` - AI-driven development platform that writes, tests, and deploys code autonomously.
+- [Ouroboros](https://github.com/Q00/ouroboros) `🌱` `[Python]` `[MCP]` - Pins an acceptance spec before the run and verifies the result, hiding grading commands from the executing agent.
 - [PR-Agent](https://github.com/The-PR-Agent/pr-agent) `🚀` `[Python]` `[GitHub]` - Open-source AI PR reviewer that auto-describes, reviews, and improves pull requests.
 - [Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) `🚀` `[TypeScript]` `[CLI]` - Open-source RLM coding and research agent designed for long-running autonomous tasks.
 - [Qodo](https://www.qodo.ai) `🚀` `[Cloud]` `[Security]` - AI code review platform with context-aware PR validation and security analysis.


### PR DESCRIPTION
Adds **Ouroboros** to `Coding Agents`.

```markdown
- [Ouroboros](https://github.com/Q00/ouroboros) `🌱` `[Python]` `[MCP]` - Pins an acceptance spec before the run and verifies the result, hiding grading commands from the executing agent.
```

**Disclosure:** I work on this project.

It sits in front of a coding agent rather than replacing it: the agent still writes the code, Ouroboros fixes the input and checks the output. The one thing it does that its closest neighbours here (Kiro, fractal) don't is that when an acceptance criterion defines a verify command or an expected-output assertion, those values are omitted from the contract block the executing agent receives, because a stuck agent optimized for the assertion string once it could see it. Redaction elsewhere is literal over five encodings, so a reshaped copy can still get through; that gap is tracked in a public issue.

One line added, nothing else touched. If I read a tier/tag/placement rule wrong, flag it and I'll fix it in this same PR instead of resubmitting.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ouroboros to the list of coding agents, highlighting acceptance-spec pinning and result verification.
  * Removed Agent Island from the agent tooling and infrastructure list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->