### PR TITLE
Add stipend.sh to MCP (Model Context Protocol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [Toolhouse](https://toolhouse.ai/en/) `🌱` `[Python]` `[Multi-Agent]` - Cloud-hosted tool infrastructure for agents with optimized execution and low-latency access.
 - [Zapier MCP Server](https://zapier.com/mcp) `🌱` `[Cloud]` `[MCP]` - Connect agents to 7,000+ app integrations via MCP, powered by Zapier's automation platform.
 - [zero-api-key-web-search](https://github.com/wd041216-bit/zero-api-key-web-search) `🌱` `[Python]` `[MCP]` - Free web search toolkit for AI agents with no API keys, MCP server support.
+- [stipend.sh](https://github.com/stipend-sh/stipend) `🔬` `[Python]` `[MCP]` - Installs a non-custodial USDC wallet on Base with spending limits enforced in the signing path.
 
 ## Browser and Computer Use Agents
 


### PR DESCRIPTION
Adding stipend.sh, a non-custodial USDC wallet on Base with an MCP server (`stipend mcp`). Source: https://github.com/stipend-sh/stipend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `stipend.sh` to the MCP tools list.
  * Documented its Base USDC non-custodial wallet and signing-path spending limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->