### PR TITLE
Add Mentioned to Sales and Outreach Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,7 @@ AI agents that automate customer support, CRM workflows, sales outreach, and tic
 - [Clay](https://www.clay.com) `🌱` `[Cloud]` `[IDE]` - Enriches leads from 70+ data providers and generates hyper-personalized outreach at scale.
 - [Instantly](https://instantly.ai) `🌱` `[Cloud]` `[Multi-Agent]` - Generates AI cold emails with smart sender rotation and built-in domain warmup for deliverability.
 - [Lavender](https://lavender.ai/) `🌱` `[Cloud]` `[Multi-Agent]` - Coaches email writing in real-time with AI response scoring and recipient intelligence.
+- [Mentioned](https://mentioned.to) `🌱` `[Cloud]` `[Managed Service]` - Finds Reddit threads ranking on Google for your keywords, then writes and publishes native posts and comments from managed accounts and tracks share of voice.
 - [OutreachAgent](https://outreachagent.dev/for-agents) `🔬` `[Cloud]` `[Event-Driven]` - Runs reply-aware outbound email workflows with webhooks, sender pacing, approvals, and deliverability guardrails.
 - [Overloop CLI](https://overloop.com) `🌱` `[Cloud]` `[CLI]` - AI outbound CLI agent that sources 450M+ contacts and runs email plus LinkedIn campaigns with JSON output.
 


### PR DESCRIPTION
Adds one entry for **Mentioned** (https://mentioned.to) to `Sales and Outreach Agents`, in alphabetical position between Lavender and OutreachAgent.

**What it is:** it finds the Reddit threads already ranking on Google for a client's keywords (and where competitors get recommended), writes and publishes native posts and comments there from managed Reddit accounts, and reports share of voice vs competitors.

**Full disclosure, so you can judge this fairly:**
- I work on Mentioned — this is a self-submission, not a neutral third-party addition.
- It is a **paid managed service**, not self-serve software and not an SDK/framework. Plans start at $2,000/month, no free tier, no open source repo.
- Founded 2025, so I used the `🌱` maturity marker.
- I used a `[Managed Service]` tag because none of the existing tags (`[Multi-Agent]`, `[MCP]`, `[CLI]`, `[Event-Driven]`) describe it accurately, and I'd rather not mislabel it. Happy to change it to whatever you prefer, or drop the entry entirely.

One line added, nothing else touched. If a human-in-the-loop managed service isn't what this list means by "agent," please just close it — thanks for maintaining the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Mentioned to the Sales and Outreach Agents list.
  * Documented its Reddit discovery, managed posting and commenting, and share-of-voice tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->