### PR TITLE
Add OpenProgram to Orchestration Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@
 - [Modus](https://github.com/hypermodeinc/modus) `🔬` `[WebAssembly]` `[Serverless]` - Serverless framework for high-throughput agent workloads with minimal cold starts.
 - [Open-AutoGLM](https://github.com/zai-org/Open-AutoGLM) `🔬` `[Python]` `[Mobile]` - Open-source phone agent framework for building mobile device automation agents.
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) `🚀` `[Python]` `[Multi-Agent]` - Lightweight multi-agent SDK with tracing and guardrails from OpenAI.
+- [OpenProgram](https://github.com/Fzkuji/OpenProgram) `🔬` `[Python]` `[Multi-Agent]` - Self-programming framework whose agents create, run, and refine workflows across models, tools, memory, and context.
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI) `🚀` `[Python]` `[MCP]` - Production multi-agent framework with self-reflection, MCP integration, and workflow automation.
 - [PydanticAI](https://github.com/pydantic/pydantic-ai) `🌱` `[Python]` `[Pydantic]` - Type-safe agent framework from the Pydantic team with a FastAPI-style developer experience.
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel) `🚀` `[C#]` `[Microsoft]` - Microsoft enterprise SDK for Python, C#, and Java with modular plugins, memory, and goal planning.


### PR DESCRIPTION
Adds [OpenProgram](https://github.com/Fzkuji/OpenProgram) to Orchestration Frameworks.

The entry meets the inclusion criteria: it is directly agent-related, functional, open source, and actively maintained. It uses the required compact format, `🔬` tier for a sub-500-star project, Python language, Multi-Agent type, alphabetical placement, and a 15-word factual description.

Validation:
- `npx awesome-lint` passes
- repository link returns successfully
- link appears once in README
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OpenProgram to the list of orchestration frameworks.
  * Identified it as a Python framework supporting multi-agent, self-programming workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->