### PR TITLE
Add Atomic Agent to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 
 - [Aider](https://github.com/Aider-AI/aider) `🌱` `[Python]` `[CLI]` - Terminal-first pair programmer that edits code in local repos, preserves Git history, and supports multi-file changes.
 - [Amazon Q Developer](https://aws.amazon.com/q/developer/) `🚀` `[Python]` `[IDE]` - AWS-native AI coding assistant with Lambda, CloudWatch, infrastructure support, and security scanning.
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) `🌱` `[TypeScript]` `[Local]` - Local-first CLI and TUI coding agent running open-weight models on your machine with no API key.
 - [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT) `🌱` `[Python]` `[CLI]` - Mature autonomous agent platform with Forge framework and public benchmarks for evaluating agent capabilities.
 - [Claude Code](https://github.com/anthropics/claude-code) `🚀` `[TypeScript]` `[Anthropic]` - Terminal-first agentic coding from Anthropic with Computer Use integration, multi-file edits, persistent shell sessions, Git operations, and fine-tuning support.
 - [Cline](https://github.com/cline/cline) `🌱` `[TypeScript]` `[VS Code]` - Autonomous coding agent in your IDE that creates/edits files, runs commands, and uses the browser with permission-gated steps.


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for putting this list together, it's genuinely one of the most useful agent roundups out there. Our team would be thrilled if you added us.

## What does this PR do?

- [x] Adds a new tool
- [ ] Updates an existing entry (stars, links, description)
- [ ] Removes an abandoned / dead project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting
- [ ] Other: ___

---

## For new tool additions

**Tool name:** Atomic Agent
**Category it belongs in:** Coding Agents
**GitHub URL:** https://github.com/AtomicBot-ai/atomic-agent
**Site URL (if any):** https://atomicagent.io

### Why does this tool belong on the list?

Atomic Agent is a local-first CLI and TUI coding agent that runs open-weight models entirely on your machine through a llama.cpp fork, so no account or API key is required to install and run it. It ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, and a five-layer local memory system, with a React and ink TUI on macOS, Linux, and Windows. Compared to the coding agents already listed, most of which call a hosted API, our differentiator is that the model itself runs locally by default while still keeping full agentic tool use.

Extra links, in case they're useful for review: docs https://atomicagent.io/docs, X https://x.com/atomicagent_io, Discord https://discord.gg/Us7qXtDGw. Install is `curl -fsSL https://atomicagent.io/install | sh`.

One honest note on maturity: the repo is about 4 months old. It's active (~2k stars, MIT licensed, commits this week) and maintained by the AtomicBot-ai organization, which ships several established projects. Happy to be tiered `🔬` instead of `🌱` if you'd prefer given the age.

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months**
- [x] This tool is **meaningfully different** from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the [format in CONTRIBUTING.md](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents/Contributing.md) exactly
- [x] The entry is placed in **alphabetical order** within its section
- [x] All links open correctly and go to the right place
- [x] Description has no promotional language (note: I wrote **one** sentence, following CONTRIBUTING.md and every existing row in the section, rather than the two this checkbox mentions, happy to expand if you'd rather)

---

## For updates or removals

**What changed and why:**

N/A, this is a new tool addition.

---

## Anything else?

The entry is a single line added to Coding Agents, between Amazon Q Developer and AutoGPT:

```markdown
- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) `🌱` `[TypeScript]` `[Local]` - Local-first CLI and TUI coding agent running open-weight models on your machine with no API key.
```

Tier `🌱` per the 500–5K star band, `[TypeScript]` as the primary implementation language, and `[Local]` as the most specific type tag. I ran `npx awesome-lint` and `codespell` locally against the edited README and both pass, and the URL doesn't appear anywhere else in the list.

Atomic Agent also arguably fits Local and Self-Hosted AI, but I kept it to a single entry since the list has no duplicate URLs anywhere and CONTRIBUTING asks for one primary category. Very happy to move it there instead if you think that's the better home.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Atomic Agent to the Coding Agents section.
  * Described its local-first TypeScript CLI/TUI experience and support for running open-weight models without an API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->