### PR TITLE
Add Duvo to Industry-Specific Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Notes: Several of these projects already appear elsewhere in this document (agen
 
 ## Industry-Specific Agents
 
-Curated list of vertical agent solutions for finance, healthcare, legal, manufacturing, and government.
+Curated list of vertical agent solutions for finance, healthcare, legal, manufacturing, retail, and government.
 
 ### Finance
 
@@ -399,7 +399,7 @@ Curated list of vertical agent solutions for finance, healthcare, legal, manufac
 
 ### Retail
 
-- [Duvo](https://www.duvo.ai) `🔬` `[Cloud]` `[Pipeline]` - Execution platform for grocery and retail operations across store, replenishment, and existing systems.
+- [Duvo](https://www.duvo.ai) `🔬` `[Cloud]` `[Pipeline]` - Execution platform for grocery and retail operations across stores, replenishment, and existing systems.
 
 ### Government & Compliance
 

--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ Curated list of vertical agent solutions for finance, healthcare, legal, manufac
 - [Siemens AI Ops](https://www.siemens.com/en-us/) `🚀` `[Cloud]` `[Multi-Agent]` - Factory-floor optimization and predictive maintenance agents.
 - [GE Predix Agents](https://www.ge.com/) `🚀` `[Cloud]` `[IDE]` - Equipment monitoring and incident prediction agents for industrial fleets.
 
+### Retail
+
+- [Duvo](https://www.duvo.ai) `🔬` `[Cloud]` `[Pipeline]` - Execution platform for grocery and retail operations across store, replenishment, and existing systems.
+
 ### Government & Compliance
 
 - Anthropic Government Agents - Policy analysis and public sector agents for regulated workflows (🏷️ `Cloud` `Government` `Enterprise`).


### PR DESCRIPTION
Adds [Duvo](https://www.duvo.ai) under a new **Retail** subsection of Industry-Specific Agents.

- [Duvo](https://www.duvo.ai) `🔬` `[Cloud]` `[Pipeline]` - Execution platform for grocery and retail operations across store, replenishment, and existing systems.

Hosted product (public URL). Format matches CONTRIBUTING compact tags. Alphabetical within the new subsection (single entry).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the Industry-Specific Agents section to include retail.
  * Added Duvo as a grocery and retail operations platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->