### PR TITLE
Add agent-qa to Agent Tooling and Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 
 - [Agent Bounties](https://github.com/NSPG13/agent-bounties) `🔬` `[Rust]` `[MCP]` - Coordinates verifiable digital bounty workflows designed for agents to post, fund, claim, solve, verify, and earn.
 - [AgentDock](https://github.com/agentdock/agentdock) `🚀` `[Python]` `[Docker]` - Framework for building and deploying production-ready AI agents with composable node architecture.
+- [agent-qa](https://github.com/vostride/agent-qa) `🌱` `[TypeScript]` `[Testing]` - Runs natural-language web and mobile tests with persistent memory and UI-change adaptation.
 - [codex-profiles](https://github.com/Ducksss/codex-profiles) `🚀` `[Python]` `[OpenAI]` - Bash CLI for switching OpenAI Codex CLI and Desktop profiles with isolated CODEX_HOME directories.
 - [CompozyOS](https://github.com/compozy/compozy) `🚀` `[Go]` `[Multi-Agent]` - Runs agent CLIs as a team on loops and schedules, with shared memory, permissions and approvals in one self-hosted daemon.
 - [Crawl4AI](https://github.com/unclecode/crawl4ai) `🌱` `[Python]` `[Multi-Agent]` - Extracts structured data from web pages using LLM-friendly output formats optimized for agent ingestion.


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool
- [ ] Updates an existing entry
- [ ] Removes an abandoned project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting

## For new tool additions

Tool name: agent-qa
Category: Agent Tooling and Infrastructure
GitHub URL: https://github.com/vostride/agent-qa

### Why does this tool belong on the list?

agent-qa is an open-source self-improving QA agent for natural-language web and mobile tests. It adds a domain-specific testing agent with persistent run memory and UI-change adaptation.

### Pre-submission checklist

- [x] Commit within the last 6 months
- [x] Meaningfully different from existing entries
- [x] Working README and documentation
- [x] Entry follows the compact format in CONTRIBUTING.md
- [x] Placed alphabetically with the Agent entries
- [x] Project link verified
- [x] Description follows the one-sentence CONTRIBUTING.md rule

### Validation

git diff --check passes. The repository-wide awesome-lint currently stops at README.md:1 with an existing repository-metadata error before checking entry content; this change does not touch that metadata.

Disclosure: I am submitting this project on behalf of its maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `agent-qa` to the Agent Tooling and Infrastructure catalog.
  * Documented its support for natural-language web and mobile testing, persistent memory, and adapting to UI changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->