### PR TITLE
Add Kolega Code to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@
 - [JetBrains AI](https://www.jetbrains.com/ai/) `🌱` `[Kotlin]` `[JetBrains]` - Deep AI integration across all JetBrains IDEs with context-aware completions and refactoring.
 - [Juggler](https://github.com/juggler-ai/juggler) `🌱` `[Desktop]` `[Local]` - Multi-client desktop/remote GUI agent with inspectable tool calls, branching-thread editable context, and plugin extensibility.
 - [Kiro](https://kiro.dev) `🚀` `[Cloud]` `[IDE]` - Spec-driven development agent that writes specs, auto-generates tasks, implements code, and automates DevOps workflows.
+- [Kolega Code](https://github.com/kolega-ai/kolega-code) `🔬` `[Python]` `[CLI]` - Terminal coding agent where the model writes its own multi-agent workflows across 15+ model providers.
 - [Open Interpreter](https://github.com/openinterpreter/openinterpreter) `🌱` `[Python]` `[CLI]` - Execute code locally via natural-language model instructions with a ChatGPT-like interface.
 - [opencode](https://github.com/anomalyco/opencode) `🌱` `[TypeScript]` `[Desktop]` - Open-source coding agent available as a desktop app with a visual interface.
 - [OpenHands](https://github.com/OpenHands/OpenHands) `🌱` `[Python]` `[Docker]` - AI-driven development platform that writes, tests, and deploys code autonomously.


### PR DESCRIPTION
Adds Kolega Code to the Coding Agents category, placed alphabetically between Kiro and Open Interpreter per the contribution guide.

Kolega Code is an open-source terminal coding agent (Python, Apache-2.0) where the model writes its own multi-agent workflows (Gigacode). It supports 15+ model providers, works as an MCP client, and keeps all session state local. Journaled sessions resume from cached results instead of repeating model calls. I used the Emerging tier since it is under 500 stars.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Kolega Code to the list of coding agents, including its repository link, status, technology, category, and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->