### PR TITLE
Add FutureOS — approval-gated agent across terminal, desktop, mobile & chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Frontend workspaces and chat interfaces with built-in agent plugins and tool-use
 - [OpenHuman](https://github.com/tinyhumansai/openhuman) `🚀` `[Rust]` `[Memory]` - Self-hosted local-first personal AI assistant with a Rust core, desktop apps, knowledge-graph memory, skills, voice, and multi-channel messaging.
 - [Orkas](https://github.com/Orkas-AI/Orkas) `🔬` `[Desktop]` `[Multi-Agent]` - Runs parallel AI agents in a local-first desktop workspace with shared files, BYOK providers, and optional sync.
 - [OpenWebUI](https://github.com/open-webui/open-webui) `🌱` `[TypeScript]` `[RAG]` - Extensible local AI interface with built-in RAG, tool use, and support for multi-agent workflows.
+- [FutureOS](https://github.com/futuregene/future-os) `🔬` `[Rust]` `[CLI]` - One approval-gated AI agent spanning terminal, desktop, mobile, and chat clients on a shared local Rust backend.
 - [lucinate](https://github.com/lucinate-ai/lucinate) `🌱` `[Go]` `[TUI]` - Multi-backend terminal AI chat client for OpenClaw, Hermes, Ollama, and OpenAI-compatible APIs with routines, multi-agent switching, and local agent skills.
 
 ## Agent Deployment and Hosting


### PR DESCRIPTION
Adding [FutureOS](https://github.com/futuregene/future-os) to the Agent Interfaces and UIs section (compact list format, alphabetically before lucinate).

FutureOS is an open-source general-purpose agent (MIT + Apache-2.0): a single local Rust gRPC backend drives a terminal UI, desktop app, mobile apps, CLI, and IM bots (Feishu/DingTalk) with shared sessions; every read/write/edit/shell tool call is approval-gated; 3,800+ models across 140+ providers built in, plus any OpenAI-compatible endpoint; local-first data storage.

Entry uses the Emerging tier badge, [Rust] language tag, and [CLI] type tag per the repo's CONTRIBUTING format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FutureOS to the Agent Interfaces and UIs section.
  * Documented its Rust CLI, approval-gated agent, and shared local backend across supported clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->