### PR TITLE
Add OB-1 to Coding Agents (open-source terminal coding agent, no API key needed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@
 - [Juggler](https://github.com/juggler-ai/juggler) `🌱` `[Desktop]` `[Local]` - Multi-client desktop/remote GUI agent with inspectable tool calls, branching-thread editable context, and plugin extensibility.
 - [Kiro](https://kiro.dev) `🚀` `[Cloud]` `[IDE]` - Spec-driven development agent that writes specs, auto-generates tasks, implements code, and automates DevOps workflows.
 - [Kolega Code](https://github.com/kolega-ai/kolega-code) `🔬` `[Python]` `[CLI]` - Terminal coding agent where the model writes its own multi-agent workflows across 15+ model providers.
+- [OB-1](https://github.com/Overbrilliant/ob-1) `🔬` `[TypeScript]` `[MCP]` - Terminal coding agent that runs with no account or API key on shared, variable-quality keyless providers, with bring-your-own-key failover.
 - [Open Interpreter](https://github.com/openinterpreter/openinterpreter) `🌱` `[Python]` `[CLI]` - Execute code locally via natural-language model instructions with a ChatGPT-like interface.
 - [opencode](https://github.com/anomalyco/opencode) `🌱` `[TypeScript]` `[Desktop]` - Open-source coding agent available as a desktop app with a visual interface.
 - [OpenHands](https://github.com/OpenHands/OpenHands) `🌱` `[Python]` `[Docker]` - AI-driven development platform that writes, tests, and deploys code autonomously.


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool
- [ ] Updates an existing entry (stars, links, description)
- [ ] Removes an abandoned / dead project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting
- [ ] Other: ___

---

## For new tool additions

**Tool name:** OB-1
**Category it belongs in:** Coding Agents
**GitHub URL:** https://github.com/Overbrilliant/ob-1
**Site URL (if any):** https://overbrilliant.com

Entry added:

```markdown
- [OB-1](https://github.com/Overbrilliant/ob-1) `🔬` `[TypeScript]` `[MCP]` - Terminal coding agent that runs with no account or API key on shared, variable-quality keyless providers, with bring-your-own-key failover.
```

Placed alphabetically between Kolega Code and Open Interpreter.

### Why does this tool belong on the list?

OB-1 is an Apache-2.0 terminal coding agent (npm `@overbrilliant/ob1`) whose default path needs no account, no API key and no card: an embedded router inside the CLI process answers the first message through keyless free providers using a signed bundled free-model catalog, so there is no server or proxy to stand up. That distinguishes it from the other entries here, which all require either a provider key (Aider, Codex CLI, Kolega Code) or local weights and hardware (Atomic Agent). It also ships persistent SQLite project memory as an inspectable fact/relationship graph, a repo map, MCP support, and OS-level sandboxing (Seatbelt on macOS, bubblewrap on Linux), and fails over to your own keys (OpenRouter, OpenAI, Gemini, Groq) or local runtimes (Ollama, LM Studio, llama.cpp, vLLM, any OpenAI-compatible endpoint).

To be straight about the trade-off: the keyless tier is a bootstrap path with variable model quality and shared limits, not a frontier-model tier. The entry says so ("shared, variable-quality keyless providers") rather than overselling it.

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months**
- [x] This tool is **meaningfully different** from existing entries
- [x] The tool has a working README or docs site
- [x] My entry follows the [format in CONTRIBUTING.md](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents-2026/blob/main/CONTRIBUTING.md) exactly
- [x] The entry is placed in **alphabetical order** within its section
- [x] All links open correctly and go to the right place
- [x] Description is exactly **two sentences** — no promotional language

Note on the last box: CONTRIBUTING.md's entry format specifies **one sentence only** (12–18 words), while this template's checkbox says two. I followed CONTRIBUTING.md and wrote one sentence of 19 words. Happy to expand it to two sentences if you prefer the template's wording, and equally happy for you to adjust the tier or the `[MCP]` type tag — I picked `[MCP]` because CONTRIBUTING.md's priority order puts `MCP` above `CLI` when both apply, but `[CLI]` would match the neighbouring entries more closely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OB-1 to the list of available coding agents.
  * Documented its TypeScript-based terminal workflow, keyless provider support, and bring-your-own-key failover option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->