### PR TITLE
Add Hermes to Voice Agent Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ Platforms for building, deploying, and scaling voice-based AI agents across call
 - [Deepgram](https://deepgram.com) `🌱` `[Cloud]` `[Pipeline]` - Sub-300ms speech-to-text and text-to-speech APIs purpose-built for real-time voice agent pipelines.
 - [ElevenLabs](https://elevenlabs.io) `🌱` `[Cloud]` `[RAG]` - Industry- voice AI with 75ms latency, Conversational AI 2.0, RAG, and HIPAA compliance.
 - [HeyGen](https://www.heygen.com) `🌱` `[Cloud]` `[IDE]` - Creates AI talking avatars with voice cloning and lip-sync for video-based agent interactions.
+- [Hermes](https://www.buildwithhermes.com) `🌱` `[Cloud]` `[Voice]` - White-label voice agent platform for agencies, bundling telephony, CRM, campaign orchestration, and usage billing so one team can run agents for many client brands.
 - [PolyAI](https://poly.ai/en) `🚀` `[Cloud]` `[Voice]` - Enterprise voice AI platform for natural multi-turn conversations with high-volume call handling.
 - [Retell AI](https://www.retellai.com) `🌱` `[Cloud]` `[Voice]` - Builds human-like voice agents with multi-language telephony support and low-latency responses.
 - [Synthesia](https://www.synthesia.io) `🌱` `[Cloud]` `[IDE]` - Generates AI video avatars that speak in 120+ languages for training and communication agents.


### PR DESCRIPTION
The Voice Agent Platforms section currently covers the pipeline layer (Deepgram, AssemblyAI, ElevenLabs) and single-tenant call automation (Bland AI, PolyAI). One category that is not yet represented is the multi-tenant / white-label layer that agencies use to run voice agents for many client brands at once, where telephony, CRM, campaign orchestration, and per-client usage billing sit in one place rather than being stitched together.

Hermes fills that slot, so I added a single entry in alphabetical position between HeyGen and PolyAI, using the exact format from CONTRIBUTING.md: tier badge, one language tag (`Cloud`, fully managed SaaS), one type tag (`Voice`), and a one sentence description.

Diff is one line in one file. Happy to adjust the tier badge or wording if maintainers prefer something different.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Hermes to the list of white-label voice agent platforms.
  * Highlighted its bundled telephony, CRM, campaign orchestration, and usage billing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->