### PR TITLE
Add Mnemoverse to Memory and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - [Memoir](https://github.com/zhangfengcdt/memoir) `🔬` `[Python]` `[Memory]` - Git-like versioned semantic memory for AI agents with branching and commits.
 - [Memvid](https://github.com/memvid/memvid) `🌱` `[Python]` `[RAG]` - Replace complex RAG pipelines with a serverless, single-file memory layer for instant retrieval.
 - [Milvus](https://github.com/milvus-io/milvus) `🌱` `[Go]` `[Vector DB]` - Scales vector search to billions of embeddings for large-scale agent knowledge bases.
+- [Mnemoverse](https://github.com/mnemoverse/mcp-memory-server) `🔬` `[TypeScript]` `[MCP]` - Hosted memory shared across Claude Code, Cursor and VS Code over MCP, with feedback that re-ranks what recall returns.
 - [Mori (森)](https://github.com/fjwood69/mori) `🌱` `[Python]` `[MCP]` - Sovereign shared memory layer for AI coding agents with zero-instrumentation capture via lifecycle hooks, a dream pipeline that distills sessions into curated governed memories, and support for Claude Code, Cursor, Codex, and Antigravity.
 - [Motorhead](https://github.com/getmetal/motorhead) `🌱` `[Rust]` `[Multi-Agent]` - Manages conversation context windows for agents with automatic background summarization.
 - [Open Index](https://github.com/DrDroidLab/open-index) `🔬` `[Python]` `[MCP]` - Builds typed knowledge graphs with hybrid search and read/write MCP tools for domain-specific agents.


### PR DESCRIPTION
## What

Adds Mnemoverse to **Memory and Context**, placed alphabetically between Milvus and Mori.

```
- [Mnemoverse](https://github.com/mnemoverse/mcp-memory-server) `🔬` `[TypeScript]` `[MCP]` - Hosted memory shared across Claude Code, Cursor and VS Code over MCP, with feedback that re-ranks what recall returns.
```

## Against the five inclusion criteria

1. **Directly related to AI agents** — an MCP server that gives agents a long-term memory; not a general LLM tool or an API wrapper.
2. **Actively maintained** — npm `@mnemoverse/mcp-memory-server` is at 0.9.1, published 2026-08-24.
3. **Publicly available** — MIT, source at the linked repo.
4. **Not a duplicate** — no occurrence of the name or the URL anywhere in the README, checked before opening this.
5. **Functional** — installable and runnable through `npx`; the server registers ten tools.

## Tier choice

`🔬` rather than `🌱`, deliberately. The repo is young and low-star, and CONTRIBUTING says experimental and few-star tools are welcome under that badge. I would rather be placed accurately than flatteringly.

## Format checks done before opening

Hyphen-space after the closing tag, no em dash anywhere in the line, one sentence, tier plus language plus type in that order, and alphabetical placement inside the section.

Disclosure: I work on Mnemoverse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Mnemoverse to the list of memory and context tools.
  * Documented support for shared memory across Claude Code, Cursor, and VS Code.
  * Noted feedback-based recall ranking to help surface more relevant remembered context.
  * Clarified that Mnemoverse is available as a hosted MCP memory service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->