### PR TITLE
Add kgai to Memory and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@
 - [Engrava](https://github.com/sovantica/engrava) `🔬` `[Python]` `[Graph-Based]` - Stores agent memory as a typed knowledge graph with hybrid search and a tamper-evident journal, embedded in SQLite.
 - [graphiti](https://github.com/getzep/graphiti) `🌱` `[Python]` `[Multi-Agent]` - Build real-time knowledge graphs for AI agents with automatic entity extraction and linking.
 - [Kage](https://github.com/kage-core/Kage) `🌱` `[TypeScript]` `[MCP]` - Git-native memory for coding agents that stores decisions and fixes as repo files and verifies them against the codebase, withholding stale knowledge.
+- [kgai](https://github.com/kgaidev/kgai) `🔬` `[Go]` `[Memory]` - Records a dev team's engineering decisions as an append-only log, synced over an S3 bucket you own.
 - [LanceDB](https://github.com/lancedb/lancedb) `🌱` `[Rust]` `[Vector DB]` - Serverless vector search database embedded directly in the agent process with no infrastructure needed.
 - [Langmem](https://github.com/langchain-ai/langmem) `🌱` `[Python]` `[LangChain]` - Helps agents learn and adapt from their interactions over time with persistent memory.
 - [Lians](https://github.com/Lians-ai/Lians) `🔬` `[Python]` `[MCP]` - Gives any AI agent local-first memory with corrections, point-in-time recall, and inspectable history.


### PR DESCRIPTION
Adds kgai to Memory and Context, alphabetically after Kage. Disclosure: we build kgai, this is a self-submission, tier set to 🔬 since the repo is young and small.

Why it belongs: kgai is memory at the level of decisions rather than conversations. It records what a dev team decided, why, and what was rejected, as an immutable append-only log that a small graph is projected from. The part the neighbours here mostly do not cover is team sharing without a server: every writer appends to their own shard in an S3 bucket the team owns, so parallel writes never produce a textual conflict. Ships as a Claude Code plugin plus a standalone Go CLI.

All five inclusion criteria hold: open source (MIT), functional and installable in two commands, actively maintained (latest release this month), documented (README, architecture docs, a series of technical reports), and it fills a niche the section lacks (append-only, team-shared, decision-level, no daemon). One line added, nothing else touched. Happy to reword to taste.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added kgai to the list of Memory and Context tools.
  * Documented its append-only engineering-decision log and S3 synchronization capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->