### PR TITLE
Add 1Claw to Agent Tooling and Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 
 Sandboxes, web scrapers, browser automation, and networking layers that agents depend on.
 
+- [1Claw](https://github.com/1clawAI/1claw-mcp) `🚀` `[TypeScript]` `[MCP]` - HSM-backed secret management for AI agents: scoped, short-lived, revocable tokens so raw keys never touch the model context, env, or logs. Also keyless multi-chain signing and prompt-injection inspection.
 - [Agent Bounties](https://github.com/NSPG13/agent-bounties) `🔬` `[Rust]` `[MCP]` - Coordinates verifiable digital bounty workflows designed for agents to post, fund, claim, solve, verify, and earn.
 - [AgentDock](https://github.com/agentdock/agentdock) `🚀` `[Python]` `[Docker]` - Framework for building and deploying production-ready AI agents with composable node architecture.
 - [agent-qa](https://github.com/vostride/agent-qa) `🌱` `[TypeScript]` `[Testing]` - Runs natural-language web and mobile tests with persistent memory and UI-change adaptation.


### PR DESCRIPTION
Adds [1Claw](https://github.com/1clawAI/1claw-mcp), an MCP server that gives AI agents secure, just-in-time access to secrets from an HSM-backed vault. Scoped, short-lived, revocable tokens so raw keys never touch the model context, environment, or logs. Also does keyless multi-chain signing and ships a no-account local prompt-injection inspector (`ONECLAW_LOCAL_ONLY=true npx -y @1claw/mcp`). In the official MCP registry as `io.github.1clawAI/1claw-mcp`. Placed under Agent Tooling and Infrastructure as a dependency agents rely on; happy to move it if you'd prefer another section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added 1Claw to the Agent Tooling and Infrastructure section.
  * Documented its HSM-backed secret management, scoped temporary tokens, keyless multi-chain signing, and prompt-injection inspection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->