### PR TITLE
Restore aeon to Orchestration Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 
 ## Orchestration Frameworks
 
+- [aeon](https://github.com/aeonfun/aeon) `🚀` `[TypeScript]` `[GitHub Actions]` - Autonomous agent framework that runs unattended on GitHub Actions, dispatching Markdown skills across ten coding-agent harnesses (Claude Code, Codex, Grok) with 1-5 quality scoring, git-persisted memory, and a self-healing repair loop.
 - [Agency Swarm](https://github.com/VRSEN/agency-swarm) `🚀` `[Python]` `[Multi-Agent]` - Orchestrates multi-agent systems built on the OpenAI Assistants API with role-based collaboration.
 - [AgentScope](https://github.com/agentscope-ai/agentscope) `🚀` `[Python]` `[Multi-Agent]` - Alibaba multi-agent framework with distributed deployment and fault tolerance for production use.
 - [Agno](https://github.com/agno-agi/agno) `🌱` `[Python]` `[Multi-Agent]` - Multi-agent framework with a runtime and control plane for managing agent deployments at scale.


### PR DESCRIPTION
aeon was added in #115 (merged 2026-06-21) but is no longer in the README - it was dropped in a later update. Re-adding it to Orchestration Frameworks.

**[aeon](https://github.com/aeonfun/aeon)** (696 stars, MIT) is an autonomous agent framework that runs unattended on GitHub Actions, dispatching Markdown skills across ten coding-agent harnesses (Claude Code, Codex, Grok) with 1-5 quality scoring, git-persisted memory, and a self-healing repair loop. Placed alphabetically at the top of the section, matching the existing badge/tag style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the Aeon autonomous agent framework to the orchestration frameworks list.
  * Highlighted its GitHub Actions execution, Markdown skills, multi-harness support, quality scoring, persisted memory, and repair loop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->