### PR TITLE
docs: add SandBase CLI to MCP agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The protocol layer that enables agents to discover tools, communicate with each 
 - [mcp-nest](https://github.com/CharanBharathula/mcp-nest) `🌱` `[Python]` `[MCP]` - Unified Model Context Protocol (MCP) server for executing code and managing files.
 - [NotFair](https://notfair.co) `🚀` `[Cloud]` `[MCP]` - Hosted Google Ads MCP server for diagnosing, optimizing, and executing campaign changes via the Google Ads API with a human-approval gate.
 - [NotFair Skills](https://github.com/nowork-studio/notfair-plugin) `🚀` `[TypeScript]` `[MCP]` - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads, connecting to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+- [SandBase CLI](https://github.com/sandbaseai/cli) `🔬` `[TypeScript]` `[MCP]` - Local MCP bridge that lets AI coding clients discover and run 2,000+ AI models and APIs.
 - [Toolhouse](https://toolhouse.ai/en/) `🌱` `[Python]` `[Multi-Agent]` - Cloud-hosted tool infrastructure for agents with optimized execution and low-latency access.
 - [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) `🔬` `[Cloud]` `[MCP]` - Hosted X Twitter data MCP for search, follower export, monitors, and confirmation-gated writes.
 - [Zapier MCP Server](https://zapier.com/mcp) `🌱` `[Cloud]` `[MCP]` - Connect agents to 7,000+ app integrations via MCP, powered by Zapier's automation platform.


### PR DESCRIPTION
## Summary
- add SandBase CLI to the MCP section
- use the required tier/language/type format
- describe its local bridge for coding clients and 2,000+ AI models/APIs

Disclosure: I contribute to SandBase CLI. This is a factual self-submitted entry linking to the canonical Apache-2.0 project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SandBase CLI to the MCP listings.
  * Described its local TypeScript bridge for discovering and running 2,000+ AI models and APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->