### PR TITLE
feat: add SandBase Harness runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Pilot Protocol](https://github.com/pilot-protocol/pilotprotocol) `🌱` `[Go]` `[Multi-Agent]` - Networking stack for distributed agent systems with encrypted tunnels.
 - [Playwright](https://github.com/microsoft/playwright) `🌱` `[TypeScript]` `[Testing]` - Automates Chromium, Firefox, and WebKit browsers with a single cross-language API for agent-driven testing.
 - [SandBase CLI](https://github.com/sandbaseai/cli) `🔬` `[TypeScript]` `[MCP]` - Connects coding agents to 2,000+ AI models through one onboarding command.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) `🌱` `[TypeScript]` `[MCP]` - Runs self-hosted agent sessions with governed tools, memory, approvals, audit/replay, and deployment-dependent Docker/Kubernetes/worker backends.
 - [ScrapeGraphAI](https://github.com/ScrapeGraphAI/Scrapegraph-ai) `🌱` `[Python]` `[LangChain]` - Python web-scraping library that uses LLMs to build intelligent scraping pipelines from natural-language instructions.
 - [Surya](https://github.com/datalab-to/surya) `🌱` `[Python]` `[CLI]` - Runs OCR and layout detection on documents in 90+ languages for multilingual document agents.
 - [Tavily](https://github.com/tavily-ai/tavily-python) `🌱` `[Python]` `[Multi-Agent]` - Search API purpose-built for LLM agents providing real-time, accurate web data with source citations.


### PR DESCRIPTION
Adds the current SandBase Harness runtime next to the existing, separate SandBase CLI entry.

- Uses the required tier/language/type format: `🌱` / TypeScript / MCP
- Places the runtime under Agent Tooling and Infrastructure
- Uses a single factual sentence and preserves deployment-dependent backend boundaries

Project: https://github.com/sandbaseai/sandbase-harness
Release: https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8
No endorsement or security certification is implied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SandBase Harness to the Agent Tooling and Infrastructure list.
  * Documented its governed agent sessions, tools, memory, approvals, audit/replay capabilities, and deployment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->