### PR TITLE
Add ClawMetry to Safety Guardrails and Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Patronus AI LYNX](https://patronus.ai/) `🌱` `[Cloud]` `[Testing]` - Hallucination detection system beating GPT-4 baselines, with specialized testing for agent outputs and LLM-generated content quality.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) `🌱` `[Python]` `[Observability]` - Open-source observability platform built on OpenTelemetry for tracing, evaluating, and debugging AI agents.
 - [Braintrust](https://www.braintrust.dev) `🌱` `[TypeScript]` `[Evaluation]` - Eval-driven development platform with experiment tracking and prompt optimization for agent quality.
+- [ClawMetry](https://github.com/vivekchand/clawmetry) `🔬` `[Python]` `[Observability]` - Self-hosted observability and kill switch for coding agents, reading the session logs runtimes already write to disk.
 - [ElevenAgents](https://elevenlabs.io/agents) `🚀` `[Cloud]` `[Voice]` - Voice agent platform from ElevenLabs for customer support automation with HIPAA compliance and multi-language support.
 - [DriftGuard](https://github.com/sujal-maheshwari2004/DriftGuard) `🌱` `[Python]` `[Multi-Agent]` - Semantic memory guardrails using causal graphs to prevent agents from repeating past failures.
 - [Galley](https://github.com/shinpr/galley) `🔬` `[Go]` `[Multi-Agent]` - Pairs independently configured executors and supervisors with repository-defined quality gates and inspectable evidence for each coding attempt.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Patronus AI LYNX](https://patronus.ai/) `🌱` `[Cloud]` `[Testing]` - Hallucination detection system beating GPT-4 baselines, with specialized testing for agent outputs and LLM-generated content quality.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) `🌱` `[Python]` `[Observability]` - Open-source observability platform built on OpenTelemetry for tracing, evaluating, and debugging AI agents.
 - [Braintrust](https://www.braintrust.dev) `🌱` `[TypeScript]` `[Evaluation]` - Eval-driven development platform with experiment tracking and prompt optimization for agent quality.
-- [ClawMetry](https://github.com/vivekchand/clawmetry) `🔬` `[Python]` `[Observability]` - Self-hosted observability and opt-in kill switch for coding agents, reading the session logs runtimes already write to disk.
+- [ClawMetry](https://github.com/vivekchand/clawmetry) `🔬` `[Python]` `[Observability]` - Self-hosted observability and opt-in kill switch for coding agents, reading the session logs runtimes already write to disk ([website](https://clawmetry.com)).
 - [ElevenAgents](https://elevenlabs.io/agents) `🚀` `[Cloud]` `[Voice]` - Voice agent platform from ElevenLabs for customer support automation with HIPAA compliance and multi-language support.
 - [DriftGuard](https://github.com/sujal-maheshwari2004/DriftGuard) `🌱` `[Python]` `[Multi-Agent]` - Semantic memory guardrails using causal graphs to prevent agents from repeating past failures.
 - [Galley](https://github.com/shinpr/galley) `🔬` `[Go]` `[Multi-Agent]` - Pairs independently configured executors and supervisors with repository-defined quality gates and inspectable evidence for each coding attempt.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Patronus AI LYNX](https://patronus.ai/) `🌱` `[Cloud]` `[Testing]` - Hallucination detection system beating GPT-4 baselines, with specialized testing for agent outputs and LLM-generated content quality.
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) `🌱` `[Python]` `[Observability]` - Open-source observability platform built on OpenTelemetry for tracing, evaluating, and debugging AI agents.
 - [Braintrust](https://www.braintrust.dev) `🌱` `[TypeScript]` `[Evaluation]` - Eval-driven development platform with experiment tracking and prompt optimization for agent quality.
-- [ClawMetry](https://github.com/vivekchand/clawmetry) `🔬` `[Python]` `[Observability]` - Self-hosted observability and kill switch for coding agents, reading the session logs runtimes already write to disk.
+- [ClawMetry](https://github.com/vivekchand/clawmetry) `🔬` `[Python]` `[Observability]` - Self-hosted observability and opt-in kill switch for coding agents, reading the session logs runtimes already write to disk.
 - [ElevenAgents](https://elevenlabs.io/agents) `🚀` `[Cloud]` `[Voice]` - Voice agent platform from ElevenLabs for customer support automation with HIPAA compliance and multi-language support.
 - [DriftGuard](https://github.com/sujal-maheshwari2004/DriftGuard) `🌱` `[Python]` `[Multi-Agent]` - Semantic memory guardrails using causal graphs to prevent agents from repeating past failures.
 - [Galley](https://github.com/shinpr/galley) `🔬` `[Go]` `[Multi-Agent]` - Pairs independently configured executors and supervisors with repository-defined quality gates and inspectable evidence for each coding attempt.


### PR DESCRIPTION
## What does this PR do?

- [x] Adds a new tool
- [ ] Updates an existing entry (stars, links, description)
- [ ] Removes an abandoned / dead project
- [ ] Fixes a broken link
- [ ] Improves structure or formatting
- [ ] Other: ___

---

## For new tool additions

**Tool name:** ClawMetry
**Category it belongs in:** Safety Guardrails and Observability
**GitHub URL:** https://github.com/vivekchand/clawmetry
**Site URL (if any):** https://clawmetry.com

### Why does this tool belong on the list?

ClawMetry is a self-hosted, local-first observability layer plus an opt-in kill switch for coding agents and agent runtimes (OpenClaw, NemoClaw, Claude Code, Codex, Cursor, Gemini CLI, Aider, Goose, Hermes, OpenCode, Cline, Copilot and others). It fits this section because it is monitoring and governance for running agents: sessions, transcripts, tool calls, tokens, cache-aware cost per session and per model, and a Guard tab that can pause, stop or kill a runaway agent (off by default). It differs from the proxy and SDK based observability tools already listed (Helicone, Langfuse, Phoenix, Logfire) in how it gets its data: it reads the session logs the runtimes already write on disk, so there is no SDK to install, nothing sits in the request path, and nothing leaves the machine by default. Zero config, `pip install clawmetry && clawmetry`.

Pricing, stated plainly so the entry does not overclaim: the open-source app (MIT, open-core) covers OpenClaw and NemoClaw for free; the other runtimes need ClawMetry Cloud or a self-hosted Pro license. Optional cloud sync is end-to-end encrypted. Tier is `🔬` because the repo is at about 400 stars and was created in February 2026.

### Pre-submission checklist

- [x] The repo has had a commit in the last **6 months** (last push 2026-09-03)
- [x] This tool is **meaningfully different** from existing entries (log-file based, no proxy or SDK, includes a process-level kill switch)
- [x] The tool has a working README or docs site
- [x] My entry follows the [format in CONTRIBUTING.md](https://github.com/ARUNAGIRINATHAN-K/awesome-ai-agents/Contributing.md) exactly (tier badge, `[Python]`, `[Observability]`, hyphen-space, one sentence of 17 words ending with a period)
- [x] The entry is placed in **alphabetical order** within its section (after Braintrust, before DriftGuard)
- [x] All links open correctly and go to the right place
- [x] Description is exactly **two sentences** — no promotional language. Note: CONTRIBUTING.md and awesome-lint require exactly one sentence, so the entry uses one sentence; happy to adjust if you prefer two.

---

## For updates or removals

**What changed and why:** Not applicable, this PR only adds one entry.

---

## Anything else?

I am the maintainer of ClawMetry. The URL does not appear elsewhere in the README and no other lines were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01Rt5fq2BWxieLpR69MAbwjr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the ClawMetry README entry to include a direct link to the project website.
  - Improved access to additional project information from the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->