### PR TITLE
Add sofagent to Safety Guardrails and Observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Sandboxes, web scrapers, browser automation, and networking layers that agents d
 - [Shipmoor](https://shipmoor.dev) `🔬` `[Python]` `[Testing]` - Local, deterministic verification layer for AI agent code: scans, test evidence, and a binding merge verdict without uploading source.
 - [SourceryKit](https://github.com/ProvablyAI/sourcerykit) `🔬` `[Python]` `[Security]` - Verifies an agent's outbound requests and MCP handoffs against a source of truth using zero-knowledge proofs, logging each call and blocking anything off the trusted-endpoint allow-list.
 - [Future AGI](https://github.com/future-agi/future-agi) `🌱` `[Python]` `[Self-Hosted]` - Self-hostable end-to-end agent engineering platform with tracing, evals, guardrails, and gateway.
+- [sofagent](https://github.com/KongFangXun/sofagent) `🔬` `[TypeScript]` `[Security]` - Commit-time audit harness that blocks credential leaks and out-of-scope file changes before they land, with 24 rules and HMAC-chained audit logs.
 
 ## Agent Interfaces and UIs
 


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) to the **Safety Guardrails and Observability** section (at section end, after Future AGI).

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

sofagent is an open-source (MIT) commit-time audit harness for AI coding agents: 24 git-diff rules (credential leaks, out-of-scope file changes, unsafe commands) enforced as a git hook, with HMAC-chained audit logs and snapshot rollback. No paid backend, fully local. It also ships as an MCP server with 80+ tools.

Related listings: [awesome-dsh-plugin #4101 (merged)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin/pull/4101) · [punkpeye/awesome-mcp-servers #13312](https://github.com/punkpeye/awesome-mcp-servers/pull/13312) · [agentrust-io/awesome-ai-governance #89](https://github.com/agentrust-io/awesome-ai-governance/pull/89)

Single-line addition to README.md only, following the compact entry format (tier/language/type tags).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `sofagent` to the Safety Guardrails and Observability documentation.
  * Documented commit-time auditing, credential-leak prevention, out-of-scope file checks, 24 validation rules, and HMAC-chained audit logs.
  * Added entries for AgentDescent and Vicoa.
  * Removed the Perplexity Personal Computer entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->