### PR TITLE
Add AI Weekly to Newsletters and Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,6 +830,7 @@ AI agents for mental health support, cognitive training, and therapy-adjacent ap
 Curated newsletters, podcasts, and communities for staying current with AI agent development.
 
 - [AI Engineering Newsletter](https://www.latent.space) `🌱` `[Python]` `[Newsletter]` - AI engineering podcast and newsletter by Swyx and Alessio covering agent architectures and tooling.
+- [AI Weekly](https://aiweekly.co) `🌱` `[Cloud]` `[Newsletter]` - Ranks models, agents, funding, policy, and research from influential AI expert signals.
 - [AiToolsObserver](https://aitoolsobserver.com) `🌱` `[Python]` `[Multi-Agent]` - AI discovery and intelligence platform covering AI agents, ecosystem trends, comparisons, and practical use cases.
 - [aibtc.news](https://aibtc.news) `🌱` `[Python]` `[Newsletter]` - Bitcoin-focused agent news platform with bounties and classifieds for the agent economy.
 - [Awesome Agents Newsletter](https://awesomeagents.substack.com) `🌱` `[Python]` `[Newsletter]` - Weekly curated tools and reviews covering the latest in AI agent development.


### PR DESCRIPTION
Adds AI Weekly to the agent directory's newsletter section using the required tier, runtime, and type tags plus a 12-word factual description. The canonical link is live and the publication has operated since 2015 for 53,000+ professionals. Disclosure: I am affiliated with AI Weekly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added AI Weekly to the Newsletters and Communities section, with its website, newsletter classification, and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->