### PR TITLE
ci: exclude lexisnexis.com from link check (HTTP/2 false positive)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -38,6 +38,7 @@ jobs:
             --exclude "agentwork-api.yfoob.chatgpt.site"
             --exclude "theagentsindex.com"
             --exclude "notfair.co"
+            --exclude "lexisnexis.com"
             --timeout 30
             README.md
           fail: true


### PR DESCRIPTION
## Summary
`Verify all links are alive` currently fails on `https://www.lexisnexis.com/en-us/gateway.page` (the LexisNexis AI entry, line 398 on PR branches) with an **HTTP/2 protocol error** — the server does not negotiate HTTP/2 properly for automated clients. The URL works fine in browsers and the entry itself is valid, so the link is not actually dead.

This adds `lexisnexis.com` to the lychee exclude list, following the same pattern already used for `mckinsey.com`, `servicenow.com`, `agentage.io`, etc.

## Why this matters
The weekly link check (and PR checks) will keep failing on this domain until it's excluded — currently blocking any PR that touches `README.md` from getting a green check.

## Testing
- lychee run log from a PR check shows `Errors: 1` with only the LexisNexis URL failing (`HTTP/2 protocol error. Server may not support HTTP/2 properly`)
- All other links, including every link added by open PRs, pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated link verification to skip links hosted on lexisnexis.com.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->