### PR TITLE
Add YYLO to Coding Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ npm install && npm run build:data && npm run dev
 - [Tabnine](https://www.tabnine.com) `🚀` `[TypeScript]` `[IDE]` - Privacy-first AI code completion with on-premise deployment and codebase fine-tuning options.
 - [TaskWeaver](https://github.com/microsoft/TaskWeaver) `🚀` `[Python]` `[Microsoft]` - A code-first agent framework from Microsoft for planning and executing data analytics tasks.
 - [Windsurf](https://devin.ai/desktop) `🌱` `[TypeScript]` `[IDE]` - AI-native IDE with Cascade agent for multi-step autonomous tasks and team workflows.
+- [YYLO](https://github.com/yylo-dev/yylo) `🔬` `[Python]` `[Multi-Agent]` - Command-line orchestrator for coding agents with typed task, validation, merge, and release-readiness boundaries in a dedicated branch/worktree.
 
 ## Memory and Context
 


### PR DESCRIPTION
## Summary

Adds [YYLO](https://github.com/yylo-dev/yylo) to **Coding Agents** — a command-line orchestrator for coding agents (it coordinates Pi and Codex subagents rather than writing code itself, the same layer as the in-section fractal and Kolega Code entries).

- Entry follows the compact format: tier `🔬` (57★ — under the 500★ Emerging band), primary language `[Python]`, type `[Multi-Agent]` (architectural style over environment per the tag priority order; matches fractal).
- Alphabetical placement at the section tail after Windsurf.
- Description phrases are quotable from the project README: "command-line orchestrator for coding agents", "typed task, validation, merge, and release-readiness boundaries", "creates a dedicated branch/worktree".

## Validation

- Inclusion criteria: directly AI-agent-related ✅; actively maintained (daily pushes since 2026-01, last push 2026-09-03) ✅; open-source MIT with GitHub repo ✅; not a duplicate (no existing entry links yylo-dev/yylo) ✅; functional (installable via `npm install -g @yylo/cli`, commands `yylo`/`yy`) ✅.
- Ran the repo pipeline locally before submitting: `node scripts/build-data.js` → **0 errors, 0 warnings** (entry parses into the dataset; generated `data/*.json` artifacts reverted — submission is README-only per the merged-add house shape).
- Link verified live.

## Disclosure

I'm on the team that builds YYLO; this submission was prepared with an AI coding agent and checked against CONTRIBUTING.md before opening. Happy to adjust the tier, tags, or category if maintainers see a better fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README registry presentation with live-registry badges, links, and a revised Vercel deployment URL.
  * Replaced the table-based contents with a list and expanded Quick Start guidance for live-registry access.
  * Added YYLO, Translation and Localization Agents, NitroTranslate, and Hearth, including updated descriptions and links.
  * Standardized several registry entries and corrected related wording.
  * Removed the Tax & Insurance placeholder and the agentbox entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->