### PR TITLE
Add ContextStream — shared project context MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ npm install && npm run build:data && npm run dev
 - [Agentage Memory](https://agentage.io) `🌱` `[Cloud]` `[MCP]` - Cross-vendor shared memory layer exposed as a remote MCP server at `memory.agentage.io/mcp` (Streamable HTTP, OAuth 2.1 + PKCE + DCR) that Claude, Cursor, and ChatGPT read and write as plain markdown you own.
 - [Chroma](https://github.com/chroma-core/chroma) `🌱` `[Python]` `[Vector DB]` - Lightweight, embeddable vector store for building memory-augmented AI agents with fast semantic retrieval.
 - [cognee](https://github.com/topoteretes/cognee) `🌱` `[Python]` `[Graph-Based]` - Knowledge engine for AI agent memory, set up in 6 lines of code with graph-based knowledge extraction.
+- [ContextStream](https://github.com/contextstream/mcp-server) `🌱` `[TypeScript]` `[MCP]` - Shared project context for Cursor, Claude Code, Codex, and Grok via hosted MCP (https://mcp.contextstream.io/mcp). Intelligence isn’t the bottleneck. Context is.
 - [Cortex Memory](https://github.com/prem-research/cortex) `🌱` `[Python]` `[Vector DB]` - Full-stack solution for agent memory covering extraction, vector search, and optimization.
 - [Engrava](https://github.com/sovantica/engrava) `🔬` `[Python]` `[Graph-Based]` - Stores agent memory as a typed knowledge graph with hybrid search and a tamper-evident journal, embedded in SQLite.
 - [graphiti](https://github.com/getzep/graphiti) `🌱` `[Python]` `[Multi-Agent]` - Build real-time knowledge graphs for AI agents with automatic entity extraction and linking.


### PR DESCRIPTION
## Add ContextStream

**Name:** ContextStream  
**URL:** https://contextstream.io  
**MCP:** https://mcp.contextstream.io/mcp  
**OSS:** https://github.com/contextstream/mcp-server  
**Benchmarks:** https://contextstream.io/benchmarks  

Shared project context for Cursor, Claude Code, Codex, Grok, and the rest. Intelligence isn’t the bottleneck. Context is.

Disclosure: I work on ContextStream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ContextStream to the README’s Memory and Context section.
  * Documented support for sharing project context across Cursor, Claude Code, Codex, and Grok via a hosted MCP endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->