### PR TITLE
Add TradingCalc MCP to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Curated list of vertical agent solutions for finance, healthcare, legal, manufac
 - [Goldman Sachs Marquee AI](https://www.goldmansachs.com) `🚀` `[Cloud]` `[Multi-Agent]` - Market data and analytics agents built on Marquee platform.
 - [Morgan Stanley AdvisorBot](https://www.morganstanley.com) `🚀` `[Cloud]` `[CLI]` - Financial advisory assistant for advisors and retail clients.
 - [AgentPump](https://agentpump.app) `🔬` `[Cloud]` `[CLI]` - Runs autonomous on-chain memecoin trading agents on Solana that trade on a schedule, operable from the terminal via the @agentpump/cli.
+- [TradingCalc MCP](https://github.com/SKalinin909/tradingcalc-mcp) `🔬` `[Cloud]` `[MCP]` - Deterministic MCP server for crypto futures math: liquidation price, PnL, position sizing, and funding cost across 17 exchanges.
 
 
 ### Healthcare


### PR DESCRIPTION
Deterministic MCP server for crypto futures math (liquidation price, PnL, position sizing, funding cost) across 17 exchanges. Remote streamable-HTTP MCP, no local runtime. Repo: https://github.com/SKalinin909/tradingcalc-mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added TradingCalc MCP to the curated Finance AI agents list.
  - Listed support for crypto futures calculations, including liquidation price, profit and loss, position sizing, and funding costs across 17 exchanges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->