### PR TITLE
Add Sillage

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Frontend workspaces and chat interfaces with built-in agent plugins and tool-use
 - [LobeHub](https://lobehub.com/) `🌱` `[TypeScript]` `[Multi-Agent]` - Modern platform for hybrid work and AI-driven collaboration with extensible agent teams and rapid integration.
 - [LobeChat](https://github.com/lobehub/lobehub) `🌱` `[TypeScript]` `[Multi-Agent]` - Modern, open-source AI chat framework with a massive plugin ecosystem for autonomous agent capabilities.
 - [OpenWebUI](https://github.com/open-webui/open-webui) `🌱` `[TypeScript]` `[RAG]` - Extensible local AI interface with built-in RAG, tool use, and support for multi-agent workflows.
+- [Sillage](https://github.com/MarlBurroW/sillage) `🔬` `[TypeScript]` `[Self-Hosted]` - Self-hosted, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine, with server-side sessions, full-text search, an IDE panel, and an installable PWA.
 
 ## Agent Deployment and Hosting
 


### PR DESCRIPTION
Adds Sillage to the Agent Interfaces and UIs section, next to AionUi and other self-hosted front-ends for CLI agents.

Entry follows the compact format: tier `🔬` Emerging (under 500 stars, recently launched), language `[TypeScript]`, type `[Self-Hosted]`, one factual sentence, no promotional language.

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine (the official agent harnesses, without a terminal). Server-side sessions that outlive the client, full-text search over every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container.

Repo: https://github.com/MarlBurroW/sillage

Disclosure: I am the author of Sillage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Sillage to the list of agent interfaces and user interfaces.
  - Documented its self-hosted, mobile-first web experience for Claude Code and Codex CLI workflows, including server-side sessions, full-text search, an IDE panel, and installable PWA support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->